### PR TITLE
Configure cross-platform Docker builds in GitHub Actions

### DIFF
--- a/.github/workflows/publish-server-app.yml
+++ b/.github/workflows/publish-server-app.yml
@@ -14,7 +14,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -36,6 +40,7 @@ jobs:
           context: .
           file: ./apps/server/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           build-args: |
             VERSION=${{ steps.get_version.outputs.VERSION }}
             SHA=${{ github.sha }}

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -7,7 +7,7 @@ ARG SHA
 RUN echo "{\"version\":\"$VERSION\",\"sha\":\"$SHA\"}" > build.json
 
 # Copy root workspace files
-COPY ../../package.json ../../package-lock.json ./
+COPY package.json package-lock.json ./
 
 # Copy scripts
 COPY ../../scripts scripts


### PR DESCRIPTION
- Added a step to set up QEMU for multi-platform builds
- Specified target platforms for Docker build: linux/amd64 and linux/arm64.
- Corrected the COPY command in Dockerfile to use relative paths correctly.