### PR TITLE
Win32 local file path URI preprocessing

### DIFF
--- a/apps/desktop/src/main/file-system.ts
+++ b/apps/desktop/src/main/file-system.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import os from 'os';
 import { Writable } from 'stream';
 
 import {
@@ -57,6 +58,22 @@ export class DesktopFileSystem implements FileSystem {
   }
 
   public async url(path: string): Promise<string> {
-    return `local-file://${path}`;
+    return `local-file://${DesktopFileSystem.win32PathPreUrl(path)}`;
+  }
+
+  public static win32PathPreUrl(path: string): string {
+    if (os.platform() === 'win32') {
+      let urlPath = path;
+      let filePathPrefix = "";
+
+      urlPath = urlPath.replace(/\\/g, '/');
+      if (/^[a-zA-Z]:/.test(urlPath)) {
+        filePathPrefix = '/';
+      }
+
+      return `${filePathPrefix}${urlPath}`;
+    }
+
+    return path;
   }
 }

--- a/apps/desktop/src/main/protocols.ts
+++ b/apps/desktop/src/main/protocols.ts
@@ -2,6 +2,7 @@ import { net } from 'electron';
 import path from 'path';
 
 import { app } from '@colanode/desktop/main/app-service';
+import { DesktopFileSystem } from '@colanode/desktop/main/file-system';
 
 export const handleAssetRequest = async (
   request: Request
@@ -56,7 +57,8 @@ export const handleAssetRequest = async (
 export const handleFileRequest = async (
   request: Request
 ): Promise<Response> => {
-  const url = request.url.replace('local-file://', '');
-  const fileUrl = `file://${url}`;
-  return net.fetch(fileUrl);
+  return net.fetch(`file://${DesktopFileSystem.win32PathPreUrl(
+      request.url.replace('local-file://', '')
+    )}`
+  );
 };


### PR DESCRIPTION
Closes #68

When the desktop app is running on os.platform() === 'win32', the path
 requires preprocessing before it can be used as part of a local file
 URI.

The logical components of this fix are:
- Add / in front of an absolute path (a path with a drive root like C:) that is already present in *nix paths because that's how the fs already represents an absolute path
- Convert all \ to / to conform to the file:// URI spec

This commit adds the required preprocessing in the file-system and
 protocols modules of the desktop app and fixes the issue of the
 disappearing account button in the SidebarMenuFooter UI component when
 a custom avatar is used for the user account that is logged in.