### PR TITLE
Make sure AvatarFallback has the size prop defined as required

### DIFF
--- a/packages/ui/src/components/avatars/avatar-image.tsx
+++ b/packages/ui/src/components/avatars/avatar-image.tsx
@@ -27,7 +27,8 @@ export const AvatarImage = ({ avatar, size, className }: AvatarProps) => {
 
   const url = data?.url;
   if (failed || !url || isPending) {
-    return <AvatarFallback id={avatar} size={size} className={className} />;
+    const avatarSize = size || 'medium';
+    return <AvatarFallback id={avatar} size={avatarSize} className={className} />;
   }
 
   return (


### PR DESCRIPTION
The AvatarFallback requires the size prop be defined. This commit adds handling to ensure that it is defined when AvatarImage
 falls back on AvatarFallback.

Closes #73