### PR TITLE
Ensure fallback of AvatarImage to AvatarFallback is handled gracefully.

### DIFF
--- a/packages/ui/src/components/avatars/avatar-image.tsx
+++ b/packages/ui/src/components/avatars/avatar-image.tsx
@@ -1,9 +1,14 @@
 import { useState } from 'react';
 
+import { getIdType } from '@colanode/core';
 import { AvatarFallback } from '@colanode/ui/components/avatars/avatar-fallback';
 import { useAccount } from '@colanode/ui/contexts/account';
 import { useQuery } from '@colanode/ui/hooks/use-query';
-import { AvatarProps, getAvatarSizeClasses } from '@colanode/ui/lib/avatars';
+import {
+  AvatarProps,
+  getAvatarSizeClasses,
+  getDefaultNodeAvatar,
+} from '@colanode/ui/lib/avatars';
 import { cn } from '@colanode/ui/lib/utils';
 
 export const AvatarImage = ({ avatar, size, className }: AvatarProps) => {
@@ -27,7 +32,15 @@ export const AvatarImage = ({ avatar, size, className }: AvatarProps) => {
 
   const url = data?.url;
   if (failed || !url || isPending) {
-    return <AvatarFallback id={avatar} size={size} className={className} />;
+    const avatarSize = size || 'medium';
+
+    const idType = getIdType(avatar);
+    const defaultAvatar = getDefaultNodeAvatar(idType);
+    if (!defaultAvatar) {
+      return <AvatarFallback id={avatar} name={account.name} size={avatarSize} className={className} />;
+    }
+
+    return <AvatarFallback id={avatar} size={avatarSize} className={className} />;
   }
 
   return (


### PR DESCRIPTION
In packages/ui/components/avatars/avatar-fallback.tsx, when called from
 packages/ui/components/avatars/avatar-image.tsx, there is no default
 icon for the av ID type (the result of calling getIdType(id: string)
 with an avatar ID in @colanode/core), and the name prop is not passed
 to AvatarFallback, so null gets returned by getDefaultNodeAvatar in
 @colanode/ui/lib/avatars and, in combination with name being null,
 causes the AvatarFallback component creation function to return null,
 and when AvatarImage with a custom avatar fails, this results in the
 account button in the SidebarMenuFooter from
 packages/ui/components/layouts/sidebars/sidebar-menu-footer.tsx to be
 completely absent (the button element is still in the DOM but it is 0-
 height) in the rendered app, and an endless failing render loop occurs
 where React tries to continuously fix it by recreating it, but the
 result is always failure.

One approach in solving this is giving the av ID type a default icon.

Another approach is passing the name prop to the AvatarFallback when
 called from AvatarImage.

This commit implements a solution for defensively taking a hybrid
 approach where when an AvatarImage is loaded and the conditional that
 triggers the fallback path (failed || !url || isPending) results in
 truthy (especially in lieu of a pending load (isPending === true)),
 progressively decay with the following logic branches:
- If there is a default icon for the ID type, use the default icon
- If there is no default icon for the ID type, pass the Account Name as the name prop when creating the AvatarFallback component (account.name)

Closes #72
Related to issue 73 also, but there is a specific branch for fixing
 that related but separate issue.