### PR TITLE
Explicitly install the native node module for the @colanode/web build

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -19,7 +19,7 @@ COPY ../../packages/ui/package.json packages/ui/package.json
 COPY ../../apps/web/package.json apps/web/package.json
 
 # Install dependencies
-RUN npm ci
+RUN npm ci && npm i --save-dev lightningcss-linux-x64-musl
 
 # Copy source files
 COPY ../../packages/core packages/core


### PR DESCRIPTION
nodejs 22 does not work properly with lightningcss.
See the corresponding discussion item [here](https://github.com/colanode/colanode/discussions/158#discussioncomment-13895100).
Similar issue in tailwindcss with oxide [here](https://github.com/tailwindlabs/tailwindcss/issues/15806) and lightningcss [here](https://github.com/tailwindlabs/tailwindcss/issues/17958).