### PR TITLE
Remove electron-fuses dependency

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -26,7 +26,6 @@
     "@electron-forge/plugin-fuses": "^7.8.3",
     "@electron-forge/plugin-vite": "^7.8.3",
     "@electron-forge/publisher-github": "^7.8.3",
-    "@electron/fuses": "^2.0.0",
     "@electron/rebuild": "^4.0.1",
     "@tailwindcss/postcss": "^4.1.12",
     "@types/better-sqlite3": "^7.6.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
         "@electron-forge/plugin-fuses": "^7.8.3",
         "@electron-forge/plugin-vite": "^7.8.3",
         "@electron-forge/publisher-github": "^7.8.3",
-        "@electron/fuses": "^2.0.0",
         "@electron/rebuild": "^4.0.1",
         "@tailwindcss/postcss": "^4.1.12",
         "@types/better-sqlite3": "^7.6.13",
@@ -66,19 +65,6 @@
         "@vitejs/plugin-react": "^5.0.2",
         "electron": "^37.4.0",
         "vite": "^7.1.3"
-      }
-    },
-    "apps/desktop/node_modules/@electron/fuses": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@electron/fuses/-/fuses-2.0.0.tgz",
-      "integrity": "sha512-lyb1zK3YHeWUjaz7yiK0GnxSPduwASKMyiDbCtbn3spP6EEt+UWtktggWehG0icFrXAk3GwvcJ4nCrJO0N9IhQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "electron-fuses": "dist/bin.js"
-      },
-      "engines": {
-        "node": ">=22.12.0"
       }
     },
     "apps/server": {


### PR DESCRIPTION
Based on the report by #201, we don't need the @electron/fuses dependency since we use @electron-forge/plugin-fuses.