### PR TITLE
Consider servers as available by default on init

### DIFF
--- a/packages/client/src/services/server-service.ts
+++ b/packages/client/src/services/server-service.ts
@@ -18,7 +18,7 @@ const debug = createDebugger('desktop:service:server');
 export class ServerService {
   private readonly app: AppService;
 
-  public state: ServerState | null = null;
+  public state: ServerState;
   public isOutdated: boolean;
 
   public readonly server: Server;
@@ -33,6 +33,13 @@ export class ServerService {
     this.socketBaseUrl = this.buildSocketBaseUrl();
     this.httpBaseUrl = this.buildHttpBaseUrl();
     this.isOutdated = isServerOutdated(server.version);
+
+    this.state = {
+      isAvailable: true,
+      lastCheckedAt: new Date(),
+      lastCheckedSuccessfullyAt: null,
+      count: 0,
+    };
   }
 
   public get isAvailable() {


### PR DESCRIPTION
We can consider the servers as available by default on init which will speed up some other operations (such as sync, uploads, downloads) to be done faster once you open Colanode instead of waiting for the server config check. Worst case these operations will fail and eventually the server will be marked as not available. This is especially helpful in web version where users can open and close tabs more frequently and faster