### PR TITLE
Fix MacOS title dots placeholder

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -6,6 +6,7 @@ import {
   shell,
   globalShortcut,
   dialog,
+  nativeTheme,
 } from 'electron';
 
 import started from 'electron-squirrel-startup';
@@ -46,6 +47,11 @@ updateElectronApp({
 
 const createWindow = async () => {
   await app.migrate();
+
+  const themeMode = (await app.metadata.get('theme.mode'))?.value;
+  if (themeMode) {
+    nativeTheme.themeSource = themeMode;
+  }
 
   // Create the browser window.
   let windowSize = (await app.metadata.get('window.size'))?.value;
@@ -114,6 +120,16 @@ const createWindow = async () => {
   const subscriptionId = eventBus.subscribe((event) => {
     if (event.type === 'query.result.updated') {
       mainWindow.webContents.send('event', event);
+    } else if (
+      event.type === 'app.metadata.updated' &&
+      event.metadata.key === 'theme.mode'
+    ) {
+      nativeTheme.themeSource = event.metadata.value;
+    } else if (
+      event.type === 'app.metadata.deleted' &&
+      event.metadata.key === 'theme.mode'
+    ) {
+      nativeTheme.themeSource = 'system';
     }
   });
 

--- a/packages/ui/src/components/layouts/sidebars/sidebar-menu.tsx
+++ b/packages/ui/src/components/layouts/sidebars/sidebar-menu.tsx
@@ -8,6 +8,7 @@ import { useApp } from '@colanode/ui/contexts/app';
 import { useRadar } from '@colanode/ui/contexts/radar';
 import { useWorkspace } from '@colanode/ui/contexts/workspace';
 import { useLiveQuery } from '@colanode/ui/hooks/use-live-query';
+import { cn } from '@colanode/ui/lib/utils';
 
 interface SidebarMenuProps {
   value: SidebarMenuType;
@@ -42,15 +43,7 @@ export const SidebarMenu = ({ value, onChange }: SidebarMenuProps) => {
 
   return (
     <div className="flex flex-col h-full w-[65px] min-w-[65px] items-center">
-      {showMacOsPlaceholder ? (
-        <div className="w-full h-8 flex gap-[8px] px-[6px] py-[7px]">
-          <div className="w-3 h-3 bg-gray-400 rounded-full"></div>
-          <div className="w-3 h-3 bg-gray-400 rounded-full"></div>
-          <div className="w-3 h-3 bg-gray-400 rounded-full"></div>
-        </div>
-      ) : (
-        <div className="w-full h-4" />
-      )}
+      <div className={cn('w-full', showMacOsPlaceholder ? 'h-8' : 'h-4')} />
       <SidebarMenuHeader />
       <div className="flex flex-col gap-1 mt-2 w-full p-2 items-center flex-grow">
         <SidebarMenuIcon


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Sync Electron theme with `theme.mode` metadata and simplify macOS sidebar titlebar placeholder to a spacer.
> 
> - **Desktop (Electron)**:
>   - Apply `app.metadata['theme.mode']` to `nativeTheme.themeSource` on startup and keep it in sync via `eventBus` updates (reset to `system` on delete).
> - **UI**:
>   - Sidebar: Replace macOS titlebar dots placeholder with a simple spacer using `cn`, preserving `h-8`/`h-4` spacing logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a52d2f858adc74abd0e2879bae425c8d5e094cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->