### PR TITLE
Server tests setup and initial tests

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -1,0 +1,66 @@
+# Colanode Server (apps/server)
+
+Colanode server is the authoritative sync, auth, and realtime layer for the local-first collaboration stack. Clients keep a local SQLite cache and sync mutation batches to this server; the server validates, persists, and broadcasts changes over WebSocket.
+
+## Architecture overview
+
+- **Runtime**: Fastify + Zod validation, WebSocket support, Redis-backed event bus, BullMQ jobs, Kysely/Postgres persistence.
+- **Data model**: Nodes, documents, collaborations, reactions, interactions, and tombstones are revisioned streams with merge-safe CRDT updates.
+- **Sync**: Clients push mutation batches; server writes to Postgres and emits events. WebSocket synchronizers stream incremental changes per entity type using revision cursors.
+- **Storage**: File data is stored via pluggable providers (file system, S3, GCS, Azure). TUS handles resumable uploads.
+- **Security**: Token-per-device authentication, rate limiting (IP + device + email), workspace authorization gates.
+
+## Requirements
+
+- Node.js 20+ (tests require this due to Vitest v4).
+- Postgres with the pgvector extension.
+- Redis (or compatible).
+- Docker is recommended for local dev and required for Testcontainers-based tests.
+
+## Quick start (local dev)
+
+From the repo root:
+
+```bash
+npm install
+docker compose -f hosting/docker/docker-compose.yaml up -d
+```
+
+From `apps/server`:
+
+```bash
+cp .env.example .env
+npm run dev
+```
+
+## Configuration
+
+The server reads configuration from a JSON file, or falls back to schema defaults in `apps/server/src/lib/config/`.
+
+- `CONFIG` points to the config JSON file.
+- `apps/server/config.example.json` is the recommended template.
+- Values can reference `env://VAR_NAME` or `file://path/to/secret` for secrets.
+- `postgres.url` is required and defaults to `env://POSTGRES_URL`.
+
+## Code map
+
+- `apps/server/src/api`: HTTP + WebSocket routes and plugins.
+- `apps/server/src/data`: database + redis clients and migrations.
+- `apps/server/src/synchronizers`: WebSocket sync streams by entity type.
+- `apps/server/src/jobs`: background jobs and handlers.
+- `apps/server/src/services`: email, jobs, and other infrastructure services.
+- `apps/server/src/lib`: shared server logic and helpers.
+
+## Tests
+
+From `apps/server`:
+
+```bash
+npm run test
+```
+
+Notes:
+
+- Tests use Testcontainers for Postgres (pgvector) and Redis. Docker must be running.
+- Fastify route tests use `fastify.inject()` (no network ports).
+- Shared test helpers live in `apps/server/test/helpers`.

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -15,15 +15,21 @@
     "build": "npm run compile && tsup-node",
     "clean": "del-cli dist isolate tsconfig.tsbuildinfo",
     "lint": "eslint . --max-warnings 0",
-    "dev": "tsx watch --env-file .env src/index.ts"
+    "dev": "tsx watch --env-file .env src/index.ts",
+    "test": "vitest run --config vitest.config.ts"
   },
   "description": "",
   "devDependencies": {
+    "@testcontainers/postgresql": "^11.11.0",
+    "@testcontainers/redis": "^11.11.0",
     "@types/node": "^25.0.3",
     "@types/nodemailer": "^7.0.4",
     "@types/pg": "^8.16.0",
     "@types/ws": "^8.18.1",
-    "tsup": "^8.5.1"
+    "testcontainers": "^11.11.0",
+    "tsup": "^8.5.1",
+    "vite-tsconfig-paths": "^6.0.4",
+    "vitest": "^4.0.17"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.965.0",

--- a/apps/server/test/api/account.test.ts
+++ b/apps/server/test/api/account.test.ts
@@ -1,0 +1,105 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { ApiHeader, UserStatus } from '@colanode/core';
+import { database } from '@colanode/server/data/database';
+import { buildTestApp } from '../helpers/app';
+import {
+  buildAuthHeader,
+  createAccount,
+  createDevice,
+  createUser,
+  createWorkspace,
+} from '../helpers/seed';
+
+const CLIENT_PLATFORM = 'test-platform';
+const CLIENT_VERSION = '1.2.3';
+const CLIENT_TYPE = 'web';
+const CLIENT_IP = '203.0.113.10';
+
+const app = buildTestApp();
+
+beforeAll(async () => {
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+describe('POST /client/v1/accounts/sync', () => {
+  it('returns only active workspaces and updates device metadata', async () => {
+    const account = await createAccount({
+      email: 'sync@example.com',
+      password: 'Password123!',
+    });
+
+    const workspace = await createWorkspace({
+      createdBy: account.id,
+    });
+
+    await createUser({
+      workspaceId: workspace.id,
+      account,
+      role: 'owner',
+    });
+
+    const hiddenWorkspace = await createWorkspace({
+      createdBy: account.id,
+      name: 'Hidden Workspace',
+    });
+
+    await createUser({
+      workspaceId: hiddenWorkspace.id,
+      account,
+      role: 'none',
+    });
+
+    const removedWorkspace = await createWorkspace({
+      createdBy: account.id,
+      name: 'Removed Workspace',
+    });
+
+    await createUser({
+      workspaceId: removedWorkspace.id,
+      account,
+      role: 'collaborator',
+      status: UserStatus.Removed,
+    });
+
+    const { device, token } = await createDevice({ accountId: account.id });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/client/v1/accounts/sync',
+      headers: {
+        ...buildAuthHeader(token),
+        [ApiHeader.ClientPlatform]: CLIENT_PLATFORM,
+        [ApiHeader.ClientVersion]: CLIENT_VERSION,
+        [ApiHeader.ClientType]: CLIENT_TYPE,
+        'x-forwarded-for': CLIENT_IP,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+
+    const body = response.json() as {
+      account: { id: string };
+      workspaces: { id: string }[];
+    };
+
+    expect(body.account.id).toBe(account.id);
+    expect(body.workspaces).toHaveLength(1);
+    expect(body.workspaces[0]?.id).toBe(workspace.id);
+
+    const updatedDevice = await database
+      .selectFrom('devices')
+      .selectAll()
+      .where('id', '=', device.id)
+      .executeTakeFirst();
+
+    expect(updatedDevice?.synced_at).not.toBeNull();
+    expect(updatedDevice?.platform).toBe(CLIENT_PLATFORM);
+    expect(updatedDevice?.version).toBe(CLIENT_VERSION);
+    expect(updatedDevice?.ip).toBe(CLIENT_IP);
+  });
+});

--- a/apps/server/test/api/auth.test.ts
+++ b/apps/server/test/api/auth.test.ts
@@ -1,0 +1,118 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { ApiErrorCode } from '@colanode/core';
+import { database } from '@colanode/server/data/database';
+import { buildTestApp } from '../helpers/app';
+import {
+  createAccount,
+  createDevice,
+  createUser,
+  createWorkspace,
+} from '../helpers/seed';
+
+const app = buildTestApp();
+
+beforeAll(async () => {
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+describe('POST /client/v1/auth/email/login', () => {
+  it('returns EmailOrPasswordIncorrect for unknown email', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/client/v1/auth/email/login',
+      payload: {
+        email: 'missing@example.com',
+        password: 'nope',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({
+      code: ApiErrorCode.EmailOrPasswordIncorrect,
+    });
+  });
+});
+
+describe('token lifecycle', () => {
+  it('creates a device on login and deletes it on logout', async () => {
+    const account = await createAccount({
+      email: 'login-user@example.com',
+      password: 'Password123!',
+    });
+
+    const workspace = await createWorkspace({
+      createdBy: account.id,
+    });
+
+    await createUser({
+      workspaceId: workspace.id,
+      account,
+      role: 'owner',
+    });
+
+    const loginResponse = await app.inject({
+      method: 'POST',
+      url: '/client/v1/auth/email/login',
+      payload: {
+        email: account.email,
+        password: 'Password123!',
+      },
+    });
+
+    expect(loginResponse.statusCode).toBe(200);
+    const loginBody = loginResponse.json();
+    expect(loginBody).toMatchObject({
+      type: 'success',
+      account: { id: account.id },
+    });
+
+    const deviceId = loginBody.deviceId as string;
+    const token = loginBody.token as string;
+
+    const device = await database
+      .selectFrom('devices')
+      .selectAll()
+      .where('id', '=', deviceId)
+      .executeTakeFirst();
+
+    expect(device).not.toBeNull();
+
+    const logoutResponse = await app.inject({
+      method: 'DELETE',
+      url: '/client/v1/auth/logout',
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+
+    expect(logoutResponse.statusCode).toBe(200);
+
+    const deletedDevice = await database
+      .selectFrom('devices')
+      .selectAll()
+      .where('id', '=', deviceId)
+      .executeTakeFirst();
+
+    expect(deletedDevice).toBeUndefined();
+
+    const logoutBody = logoutResponse.json();
+    expect(logoutBody).toMatchObject({});
+  });
+
+  it('rejects logout without a token', async () => {
+    const logoutResponse = await app.inject({
+      method: 'DELETE',
+      url: '/client/v1/auth/logout',
+    });
+
+    expect(logoutResponse.statusCode).toBe(401);
+    expect(logoutResponse.json()).toMatchObject({
+      code: ApiErrorCode.TokenMissing,
+    });
+  });
+});

--- a/apps/server/test/api/files.test.ts
+++ b/apps/server/test/api/files.test.ts
@@ -1,0 +1,192 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { ApiErrorCode, FileStatus } from '@colanode/core';
+import { database } from '@colanode/server/data/database';
+import { updateNode } from '@colanode/server/lib/nodes';
+import { buildTestApp } from '../helpers/app';
+import {
+  buildAuthHeader,
+  createAccount,
+  createDevice,
+  createFileNode,
+  createSpaceNode,
+  createUser,
+  createWorkspace,
+} from '../helpers/seed';
+
+const app = buildTestApp();
+
+beforeAll(async () => {
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+const extractPath = (location?: string) => {
+  if (!location) {
+    throw new Error('Missing Location header');
+  }
+
+  try {
+    const url = new URL(location);
+    return url.pathname;
+  } catch {
+    return location;
+  }
+};
+
+describe('file uploads', () => {
+  it('marks file Ready and sets uploaded_at after TUS completion', async () => {
+    const account = await createAccount({
+      email: 'upload@example.com',
+    });
+
+    const workspace = await createWorkspace({
+      createdBy: account.id,
+    });
+
+    const user = await createUser({
+      workspaceId: workspace.id,
+      account,
+      role: 'owner',
+    });
+
+    const { token } = await createDevice({ accountId: account.id });
+
+    const rootId = await createSpaceNode({
+      workspaceId: workspace.id,
+      userId: user.id,
+    });
+
+    const payload = Buffer.from('hello world');
+    const fileId = await createFileNode({
+      workspaceId: workspace.id,
+      userId: user.id,
+      parentId: rootId,
+      rootId,
+      size: payload.length,
+      name: 'upload.txt',
+      extension: '.txt',
+    });
+
+    const createResponse = await app.inject({
+      method: 'POST',
+      url: `/client/v1/workspaces/${workspace.id}/files/${fileId}/tus`,
+      headers: {
+        ...buildAuthHeader(token),
+        'Tus-Resumable': '1.0.0',
+        'Upload-Length': payload.length.toString(),
+      },
+    });
+
+    expect([201, 204]).toContain(createResponse.statusCode);
+
+    const location = createResponse.headers.location as string | undefined;
+    const uploadPath = extractPath(location);
+
+    const patchResponse = await app.inject({
+      method: 'PATCH',
+      url: uploadPath,
+      headers: {
+        ...buildAuthHeader(token),
+        'Tus-Resumable': '1.0.0',
+        'Upload-Offset': '0',
+        'Content-Type': 'application/offset+octet-stream',
+        'Content-Length': payload.length.toString(),
+      },
+      payload,
+    });
+
+    expect([200, 204]).toContain(patchResponse.statusCode);
+
+    const upload = await database
+      .selectFrom('uploads')
+      .selectAll()
+      .where('file_id', '=', fileId)
+      .executeTakeFirst();
+
+    expect(upload?.uploaded_at).not.toBeNull();
+
+    const node = await database
+      .selectFrom('nodes')
+      .selectAll()
+      .where('id', '=', fileId)
+      .executeTakeFirst();
+
+    expect(node).not.toBeNull();
+    const attributes = node?.attributes as { status?: number } | null;
+    expect(attributes?.status).toBe(FileStatus.Ready);
+  });
+});
+
+describe('file download guards', () => {
+  it('rejects download when file is not ready or upload missing', async () => {
+    const account = await createAccount({
+      email: 'download@example.com',
+    });
+
+    const workspace = await createWorkspace({
+      createdBy: account.id,
+    });
+
+    const user = await createUser({
+      workspaceId: workspace.id,
+      account,
+      role: 'owner',
+    });
+
+    const { token } = await createDevice({ accountId: account.id });
+
+    const rootId = await createSpaceNode({
+      workspaceId: workspace.id,
+      userId: user.id,
+    });
+
+    const fileId = await createFileNode({
+      workspaceId: workspace.id,
+      userId: user.id,
+      parentId: rootId,
+      rootId,
+      size: 10,
+    });
+
+    const notReadyResponse = await app.inject({
+      method: 'GET',
+      url: `/client/v1/workspaces/${workspace.id}/files/${fileId}`,
+      headers: buildAuthHeader(token),
+    });
+
+    expect(notReadyResponse.statusCode).toBe(400);
+    expect(notReadyResponse.json()).toMatchObject({
+      code: ApiErrorCode.FileNotReady,
+    });
+
+    const updated = await updateNode({
+      nodeId: fileId,
+      userId: user.id,
+      workspaceId: workspace.id,
+      updater(attributes) {
+        if (attributes.type !== 'file') {
+          throw new Error('Node is not a file');
+        }
+        attributes.status = FileStatus.Ready;
+        return attributes;
+      },
+    });
+
+    expect(updated).toBe(true);
+
+    const missingUploadResponse = await app.inject({
+      method: 'GET',
+      url: `/client/v1/workspaces/${workspace.id}/files/${fileId}`,
+      headers: buildAuthHeader(token),
+    });
+
+    expect(missingUploadResponse.statusCode).toBe(400);
+    expect(missingUploadResponse.json()).toMatchObject({
+      code: ApiErrorCode.FileUploadNotFound,
+    });
+  });
+});

--- a/apps/server/test/api/mutations.test.ts
+++ b/apps/server/test/api/mutations.test.ts
@@ -1,0 +1,170 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { IdType, MutationStatus, generateId } from '@colanode/core';
+import { database } from '@colanode/server/data/database';
+import { jobService } from '@colanode/server/services/job-service';
+import { buildTestApp } from '../helpers/app';
+import {
+  buildAuthHeader,
+  buildCreateNodeMutation,
+  createAccount,
+  createDevice,
+  createPageNode,
+  createSpaceNode,
+  createUser,
+  createWorkspace,
+} from '../helpers/seed';
+
+const app = buildTestApp();
+
+beforeAll(async () => {
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+describe('mutation idempotency', () => {
+  it('returns CREATED then OK for repeated node.create', async () => {
+    const account = await createAccount({
+      email: 'mutations@example.com',
+      password: 'Password123!',
+    });
+
+    const workspace = await createWorkspace({
+      createdBy: account.id,
+    });
+
+    const user = await createUser({
+      workspaceId: workspace.id,
+      account,
+      role: 'owner',
+    });
+
+    const { token } = await createDevice({ accountId: account.id });
+
+    const nodeId = generateId(IdType.Space);
+    const mutation = buildCreateNodeMutation({
+      nodeId,
+      attributes: {
+        type: 'space',
+        name: 'Idempotent Space',
+        visibility: 'private',
+        collaborators: {
+          [user.id]: 'admin',
+        },
+      },
+    });
+
+    const secondMutation = {
+      ...mutation,
+      id: generateId(IdType.Mutation),
+    };
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/client/v1/workspaces/${workspace.id}/mutations`,
+      headers: buildAuthHeader(token),
+      payload: {
+        mutations: [mutation, secondMutation],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as { results: { status: number }[] };
+
+    expect(body.results[0]?.status).toBe(MutationStatus.CREATED);
+    expect(body.results[1]?.status).toBe(MutationStatus.OK);
+  });
+});
+
+describe('delete cascade', () => {
+  it('creates a tombstone and schedules cleanup on node.delete', async () => {
+    const account = await createAccount({
+      email: 'delete@example.com',
+    });
+
+    const workspace = await createWorkspace({
+      createdBy: account.id,
+    });
+
+    const user = await createUser({
+      workspaceId: workspace.id,
+      account,
+      role: 'owner',
+    });
+
+    const { token } = await createDevice({ accountId: account.id });
+
+    const rootId = await createSpaceNode({
+      workspaceId: workspace.id,
+      userId: user.id,
+    });
+
+    const pageId = await createPageNode({
+      workspaceId: workspace.id,
+      userId: user.id,
+      parentId: rootId,
+      rootId,
+    });
+
+    const addJobSpy = vi
+      .spyOn(jobService, 'addJob')
+      .mockResolvedValue(undefined);
+
+    const deletedAt = new Date().toISOString();
+    const response = await app.inject({
+      method: 'POST',
+      url: `/client/v1/workspaces/${workspace.id}/mutations`,
+      headers: buildAuthHeader(token),
+      payload: {
+        mutations: [
+          {
+            id: generateId(IdType.Mutation),
+            createdAt: deletedAt,
+            type: 'node.delete',
+            data: {
+              nodeId: pageId,
+              rootId,
+              deletedAt,
+            },
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as { results: { status: number }[] };
+    expect(body.results[0]?.status).toBe(MutationStatus.OK);
+
+    const deletedNode = await database
+      .selectFrom('nodes')
+      .selectAll()
+      .where('id', '=', pageId)
+      .executeTakeFirst();
+
+    expect(deletedNode).toBeUndefined();
+
+    const tombstone = await database
+      .selectFrom('node_tombstones')
+      .selectAll()
+      .where('id', '=', pageId)
+      .executeTakeFirst();
+
+    expect(tombstone).not.toBeNull();
+    expect(tombstone?.root_id).toBe(rootId);
+
+    expect(addJobSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'node.clean',
+        nodeId: pageId,
+        parentId: rootId,
+        workspaceId: workspace.id,
+        userId: user.id,
+      })
+    );
+
+    addJobSpy.mockRestore();
+  });
+});

--- a/apps/server/test/api/workspace.test.ts
+++ b/apps/server/test/api/workspace.test.ts
@@ -1,0 +1,243 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  ApiErrorCode,
+  IdType,
+  UserStatus,
+  WorkspaceStatus,
+  generateId,
+} from '@colanode/core';
+import { database } from '@colanode/server/data/database';
+import { buildTestApp } from '../helpers/app';
+import {
+  buildAuthHeader,
+  buildCreateNodeMutation,
+  createAccount,
+  createDevice,
+  createUser,
+  createWorkspace,
+} from '../helpers/seed';
+
+const app = buildTestApp();
+
+beforeAll(async () => {
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+describe('workspace access', () => {
+  it('rejects users with role none', async () => {
+    const account = await createAccount({
+      email: 'no-role@example.com',
+      password: 'Password123!',
+    });
+
+    const workspace = await createWorkspace({
+      createdBy: account.id,
+      status: WorkspaceStatus.Active,
+    });
+
+    await createUser({
+      workspaceId: workspace.id,
+      account,
+      role: 'none',
+    });
+
+    const { token } = await createDevice({ accountId: account.id });
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/client/v1/workspaces/${workspace.id}`,
+      headers: buildAuthHeader(token),
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toMatchObject({
+      code: ApiErrorCode.WorkspaceNoAccess,
+    });
+  });
+});
+
+describe('workspace readonly guard', () => {
+  it('rejects mutations when workspace is not active (readonly)', async () => {
+    const account = await createAccount({
+      email: 'readonly@example.com',
+    });
+
+    const workspace = await createWorkspace({
+      createdBy: account.id,
+      status: WorkspaceStatus.Readonly,
+    });
+
+    const user = await createUser({
+      workspaceId: workspace.id,
+      account,
+      role: 'owner',
+    });
+
+    const { token } = await createDevice({ accountId: account.id });
+
+    const mutation = buildCreateNodeMutation({
+      nodeId: generateId(IdType.Space),
+      attributes: {
+        type: 'space',
+        name: 'Readonly Space',
+        visibility: 'private',
+        collaborators: {
+          [user.id]: 'admin',
+        },
+      },
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/client/v1/workspaces/${workspace.id}/mutations`,
+      headers: buildAuthHeader(token),
+      payload: {
+        mutations: [mutation],
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toMatchObject({
+      code: ApiErrorCode.WorkspaceNoAccess,
+    });
+  });
+});
+
+describe('workspace user invites', () => {
+  it('rejects invites from non-admin roles', async () => {
+    const account = await createAccount({
+      email: 'invite@example.com',
+    });
+
+    const workspace = await createWorkspace({
+      createdBy: account.id,
+    });
+
+    await createUser({
+      workspaceId: workspace.id,
+      account,
+      role: 'guest',
+    });
+
+    const { token } = await createDevice({ accountId: account.id });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: `/client/v1/workspaces/${workspace.id}/users`,
+      headers: buildAuthHeader(token),
+      payload: {
+        users: [
+          {
+            email: 'new-user@example.com',
+            role: 'collaborator',
+          },
+        ],
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toMatchObject({
+      code: ApiErrorCode.UserInviteNoAccess,
+    });
+  });
+});
+
+describe('workspace role updates', () => {
+  it('rejects role updates from non-admin users', async () => {
+    const account = await createAccount({
+      email: 'role-update@example.com',
+    });
+
+    const workspace = await createWorkspace({
+      createdBy: account.id,
+    });
+
+    await createUser({
+      workspaceId: workspace.id,
+      account,
+      role: 'guest',
+    });
+
+    const targetAccount = await createAccount({
+      email: 'role-target@example.com',
+    });
+
+    const targetUser = await createUser({
+      workspaceId: workspace.id,
+      account: targetAccount,
+      role: 'collaborator',
+    });
+
+    const { token } = await createDevice({ accountId: account.id });
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: `/client/v1/workspaces/${workspace.id}/users/${targetUser.id}/role`,
+      headers: buildAuthHeader(token),
+      payload: {
+        role: 'admin',
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toMatchObject({
+      code: ApiErrorCode.UserUpdateNoAccess,
+    });
+  });
+
+  it('sets status to Removed when role is none', async () => {
+    const ownerAccount = await createAccount({
+      email: 'role-owner@example.com',
+    });
+
+    const workspace = await createWorkspace({
+      createdBy: ownerAccount.id,
+    });
+
+    await createUser({
+      workspaceId: workspace.id,
+      account: ownerAccount,
+      role: 'owner',
+    });
+
+    const memberAccount = await createAccount({
+      email: 'role-member@example.com',
+    });
+
+    const memberUser = await createUser({
+      workspaceId: workspace.id,
+      account: memberAccount,
+      role: 'collaborator',
+    });
+
+    const { token } = await createDevice({ accountId: ownerAccount.id });
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: `/client/v1/workspaces/${workspace.id}/users/${memberUser.id}/role`,
+      headers: buildAuthHeader(token),
+      payload: {
+        role: 'none',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as { status: number; role: string };
+    expect(body.role).toBe('none');
+    expect(body.status).toBe(UserStatus.Removed);
+
+    const updatedUser = await database
+      .selectFrom('users')
+      .selectAll()
+      .where('id', '=', memberUser.id)
+      .executeTakeFirst();
+
+    expect(updatedUser?.status).toBe(UserStatus.Removed);
+    expect(updatedUser?.role).toBe('none');
+  });
+});

--- a/apps/server/test/global-setup.ts
+++ b/apps/server/test/global-setup.ts
@@ -1,0 +1,66 @@
+import os from 'node:os';
+import path from 'node:path';
+import { writeFile } from 'node:fs/promises';
+
+import { PostgreSqlContainer } from '@testcontainers/postgresql';
+import { RedisContainer } from '@testcontainers/redis';
+
+type TestEnvConfig = {
+  POSTGRES_URL: string;
+  REDIS_URL: string;
+  CONFIG: string;
+  NODE_ENV: string;
+};
+
+const ENV_PATH = path.join(os.tmpdir(), 'colanode-test-env.json');
+const CONFIG_PATH = path.join(os.tmpdir(), 'colanode-test-config.json');
+
+export default async function globalSetup() {
+  const postgres = await new PostgreSqlContainer('pgvector/pgvector:pg17')
+    .withDatabase('colanode_test')
+    .withUsername('postgres')
+    .withPassword('postgres')
+    .start();
+
+  const redis = await new RedisContainer('redis:7-alpine').start();
+
+  const testConfig = {
+    mode: 'standalone',
+    logging: { level: 'silent' },
+    email: { enabled: false },
+    jobs: {
+      nodeUpdatesMerge: { enabled: false },
+      documentUpdatesMerge: { enabled: false },
+      cleanup: { enabled: false },
+    },
+    storage: {
+      tus: { locker: { type: 'memory' }, cache: { type: 'none' } },
+      provider: {
+        type: 'file',
+        directory: path.join(os.tmpdir(), 'colanode-test-storage'),
+      },
+    },
+  };
+
+  await writeFile(CONFIG_PATH, JSON.stringify(testConfig));
+
+  const envConfig: TestEnvConfig = {
+    POSTGRES_URL: postgres.getConnectionUri(),
+    REDIS_URL: redis.getConnectionUrl(),
+    CONFIG: CONFIG_PATH,
+    NODE_ENV: 'test',
+  };
+
+  await writeFile(ENV_PATH, JSON.stringify(envConfig));
+
+  Object.assign(process.env, envConfig);
+
+  const { migrate, database } = await import('../src/data/database');
+  await migrate();
+  await database.destroy();
+
+  return async () => {
+    await redis.stop();
+    await postgres.stop();
+  };
+}

--- a/apps/server/test/helpers/app.ts
+++ b/apps/server/test/helpers/app.ts
@@ -1,0 +1,25 @@
+import fastifyWebsocket from '@fastify/websocket';
+import { fastify, FastifyInstance } from 'fastify';
+import {
+  serializerCompiler,
+  validatorCompiler,
+} from 'fastify-type-provider-zod';
+
+import { apiRoutes } from '@colanode/server/api';
+import { clientDecorator } from '@colanode/server/api/client/plugins/client';
+import { corsPlugin } from '@colanode/server/api/client/plugins/cors';
+import { errorHandler } from '@colanode/server/api/client/plugins/error-handler';
+
+export const buildTestApp = (): FastifyInstance => {
+  const app = fastify();
+
+  app.register(errorHandler);
+  app.setSerializerCompiler(serializerCompiler);
+  app.setValidatorCompiler(validatorCompiler);
+  app.register(corsPlugin);
+  app.register(fastifyWebsocket);
+  app.register(clientDecorator);
+  app.register(apiRoutes);
+
+  return app;
+};

--- a/apps/server/test/helpers/seed.ts
+++ b/apps/server/test/helpers/seed.ts
@@ -1,0 +1,285 @@
+import {
+  AccountStatus,
+  generateId,
+  IdType,
+  UserStatus,
+  WorkspaceStatus,
+} from '@colanode/core';
+import { YDoc } from '@colanode/crdt';
+import { database } from '@colanode/server/data/database';
+import type {
+  SelectAccount,
+  SelectDevice,
+  SelectUser,
+  SelectWorkspace,
+} from '@colanode/server/data/schema';
+import { generatePasswordHash } from '@colanode/server/lib/accounts';
+import { createNode } from '@colanode/server/lib/nodes';
+import { generateToken } from '@colanode/server/lib/tokens';
+import { DeviceType } from '@colanode/server/types/devices';
+import { getNodeModel, NodeAttributes } from '@colanode/core';
+import { FileStatus } from '@colanode/core';
+
+export const createAccount = async (input?: {
+  email?: string;
+  name?: string;
+  status?: AccountStatus;
+  password?: string | null;
+}): Promise<SelectAccount> => {
+  const email = input?.email ?? `user-${generateId(IdType.Account)}@example.com`;
+  const name = input?.name ?? 'Test User';
+  const status = input?.status ?? AccountStatus.Active;
+
+  const password = input?.password ?? 'password123';
+  const passwordHash =
+    password === null ? null : await generatePasswordHash(password);
+
+  const account = await database
+    .insertInto('accounts')
+    .returningAll()
+    .values({
+      id: generateId(IdType.Account),
+      name,
+      email,
+      avatar: null,
+      password: passwordHash,
+      attributes: null,
+      created_at: new Date(),
+      updated_at: null,
+      status,
+    })
+    .executeTakeFirst();
+
+  if (!account) {
+    throw new Error('Failed to create account');
+  }
+
+  return account;
+};
+
+export const createWorkspace = async (input: {
+  createdBy: string;
+  name?: string;
+  status?: WorkspaceStatus;
+}): Promise<SelectWorkspace> => {
+  const workspace = await database
+    .insertInto('workspaces')
+    .returningAll()
+    .values({
+      id: generateId(IdType.Workspace),
+      name: input.name ?? 'Test Workspace',
+      description: null,
+      avatar: null,
+      attrs: null,
+      created_at: new Date(),
+      created_by: input.createdBy,
+      updated_at: null,
+      updated_by: null,
+      status: input.status ?? WorkspaceStatus.Active,
+      max_file_size: null,
+    })
+    .executeTakeFirst();
+
+  if (!workspace) {
+    throw new Error('Failed to create workspace');
+  }
+
+  return workspace;
+};
+
+export const createUser = async (input: {
+  workspaceId: string;
+  account: SelectAccount;
+  role: 'owner' | 'admin' | 'collaborator' | 'guest' | 'none';
+  status?: UserStatus;
+}): Promise<SelectUser> => {
+  const user = await database
+    .insertInto('users')
+    .returningAll()
+    .values({
+      id: generateId(IdType.User),
+      account_id: input.account.id,
+      workspace_id: input.workspaceId,
+      role: input.role,
+      name: input.account.name,
+      email: input.account.email,
+      avatar: input.account.avatar,
+      custom_name: null,
+      custom_avatar: null,
+      created_at: new Date(),
+      created_by: input.account.id,
+      status: input.status ?? UserStatus.Active,
+      max_file_size: '0',
+      storage_limit: '0',
+    })
+    .executeTakeFirst();
+
+  if (!user) {
+    throw new Error('Failed to create user');
+  }
+
+  return user;
+};
+
+export const createDevice = async (input: {
+  accountId: string;
+}): Promise<{ device: SelectDevice; token: string }> => {
+  const deviceId = generateId(IdType.Device);
+  const { token, salt, hash } = generateToken(deviceId);
+
+  const device = await database
+    .insertInto('devices')
+    .returningAll()
+    .values({
+      id: deviceId,
+      account_id: input.accountId,
+      token_hash: hash,
+      token_salt: salt,
+      token_generated_at: new Date(),
+      previous_token_hash: null,
+      previous_token_salt: null,
+      type: DeviceType.Web,
+      version: 'test',
+      platform: 'test',
+      ip: '127.0.0.1',
+      created_at: new Date(),
+      synced_at: null,
+    })
+    .executeTakeFirst();
+
+  if (!device) {
+    throw new Error('Failed to create device');
+  }
+
+  return { device, token };
+};
+
+export const createSpaceNode = async (input: {
+  workspaceId: string;
+  userId: string;
+  name?: string;
+}): Promise<string> => {
+  const spaceId = generateId(IdType.Space);
+  const attributes: NodeAttributes = {
+    type: 'space',
+    name: input.name ?? 'Test Space',
+    description: null,
+    avatar: null,
+    visibility: 'private',
+    collaborators: {
+      [input.userId]: 'admin',
+    },
+  };
+
+  const created = await createNode({
+    nodeId: spaceId,
+    rootId: spaceId,
+    attributes,
+    userId: input.userId,
+    workspaceId: input.workspaceId,
+  });
+
+  if (!created) {
+    throw new Error('Failed to create space node');
+  }
+
+  return spaceId;
+};
+
+export const createPageNode = async (input: {
+  workspaceId: string;
+  userId: string;
+  parentId: string;
+  rootId: string;
+  name?: string;
+}): Promise<string> => {
+  const pageId = generateId(IdType.Page);
+  const attributes: NodeAttributes = {
+    type: 'page',
+    name: input.name ?? 'Test Page',
+    parentId: input.parentId,
+  };
+
+  const created = await createNode({
+    nodeId: pageId,
+    rootId: input.rootId,
+    attributes,
+    userId: input.userId,
+    workspaceId: input.workspaceId,
+  });
+
+  if (!created) {
+    throw new Error('Failed to create page node');
+  }
+
+  return pageId;
+};
+
+export const createFileNode = async (input: {
+  workspaceId: string;
+  userId: string;
+  parentId: string;
+  rootId: string;
+  size: number;
+  name?: string;
+  extension?: string;
+}): Promise<string> => {
+  const fileId = generateId(IdType.File);
+  const attributes: NodeAttributes = {
+    type: 'file',
+    subtype: 'other',
+    parentId: input.parentId,
+    name: input.name ?? 'Test File',
+    originalName: input.name ?? 'test.txt',
+    mimeType: 'text/plain',
+    extension: input.extension ?? '.txt',
+    size: input.size,
+    version: '1',
+    status: FileStatus.Pending,
+  };
+
+  const created = await createNode({
+    nodeId: fileId,
+    rootId: input.rootId,
+    attributes,
+    userId: input.userId,
+    workspaceId: input.workspaceId,
+  });
+
+  if (!created) {
+    throw new Error('Failed to create file node');
+  }
+
+  return fileId;
+};
+
+export const buildCreateNodeMutation = (input: {
+  nodeId: string;
+  attributes: NodeAttributes;
+  createdAt?: string;
+}) => {
+  const model = getNodeModel(input.attributes.type);
+  const ydoc = new YDoc();
+  const update = ydoc.update(model.attributesSchema, input.attributes);
+  if (!update) {
+    throw new Error('Failed to create node update');
+  }
+
+  const createdAt = input.createdAt ?? new Date().toISOString();
+
+  return {
+    id: generateId(IdType.Mutation),
+    createdAt,
+    type: 'node.create' as const,
+    data: {
+      nodeId: input.nodeId,
+      updateId: generateId(IdType.Update),
+      createdAt,
+      data: ydoc.getEncodedState(),
+    },
+  };
+};
+
+export const buildAuthHeader = (token: string) => {
+  return { authorization: `Bearer ${token}` };
+};

--- a/apps/server/test/lib/utils.test.ts
+++ b/apps/server/test/lib/utils.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { compareString, getNameFromEmail } from '@colanode/server/lib/utils';
+
+describe('utils', () => {
+  it('builds display names from email local parts', () => {
+    expect(getNameFromEmail('jane.doe@example.com')).toBe('Jane Doe');
+    expect(getNameFromEmail('john_doe-smith@example.com')).toBe(
+      'John Doe Smith'
+    );
+  });
+
+  it('compares strings with nulls and undefined', () => {
+    expect(compareString('a', 'a')).toBe(0);
+    expect(compareString(undefined, 'a')).toBe(-1);
+    expect(compareString('a', undefined)).toBe(1);
+  });
+});

--- a/apps/server/test/setup-env.ts
+++ b/apps/server/test/setup-env.ts
@@ -1,0 +1,46 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll } from 'vitest';
+
+type TestEnvConfig = {
+  POSTGRES_URL: string;
+  REDIS_URL: string;
+  CONFIG: string;
+  NODE_ENV: string;
+};
+
+const ENV_PATH = path.join(os.tmpdir(), 'colanode-test-env.json');
+
+if (!fs.existsSync(ENV_PATH)) {
+  throw new Error(`Test env file not found at ${ENV_PATH}`);
+}
+
+const envConfig = JSON.parse(
+  fs.readFileSync(ENV_PATH, 'utf-8')
+) as TestEnvConfig;
+
+Object.assign(process.env, envConfig);
+
+let redis: typeof import('../src/data/redis').redis | null = null;
+let database: typeof import('../src/data/database').database | null = null;
+
+beforeAll(async () => {
+  const redisModule = await import('../src/data/redis');
+  await redisModule.initRedis();
+  redis = redisModule.redis;
+
+  const dbModule = await import('../src/data/database');
+  database = dbModule.database;
+});
+
+afterAll(async () => {
+  if (redis) {
+    await redis.quit();
+  }
+
+  if (database) {
+    await database.destroy();
+  }
+});

--- a/apps/server/test/synchronizers/collaborations.test.ts
+++ b/apps/server/test/synchronizers/collaborations.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { database } from '@colanode/server/data/database';
+import { CollaborationSynchronizer } from '@colanode/server/synchronizers/collaborations';
+import { generateId, IdType } from '@colanode/core';
+
+const createCollaborationRow = async (input: {
+  workspaceId: string;
+  collaboratorId: string;
+  nodeId: string;
+  role: string;
+}) => {
+  return database
+    .insertInto('collaborations')
+    .returningAll()
+    .values({
+      node_id: input.nodeId,
+      collaborator_id: input.collaboratorId,
+      workspace_id: input.workspaceId,
+      role: input.role,
+      created_at: new Date(),
+      created_by: input.collaboratorId,
+      updated_at: null,
+      updated_by: null,
+      deleted_at: null,
+      deleted_by: null,
+    })
+    .executeTakeFirstOrThrow();
+};
+
+describe('CollaborationSynchronizer', () => {
+  it('returns collaborations in revision order after the cursor', async () => {
+    const workspaceId = generateId(IdType.Workspace);
+    const collaboratorId = generateId(IdType.User);
+
+    const first = await createCollaborationRow({
+      workspaceId,
+      collaboratorId,
+      nodeId: generateId(IdType.Space),
+      role: 'admin',
+    });
+
+    const second = await createCollaborationRow({
+      workspaceId,
+      collaboratorId,
+      nodeId: generateId(IdType.Page),
+      role: 'editor',
+    });
+
+    const synchronizer = new CollaborationSynchronizer(
+      'sync-collabs',
+      {
+        userId: collaboratorId,
+        workspaceId,
+        accountId: generateId(IdType.Account),
+        deviceId: generateId(IdType.Device),
+      },
+      { type: 'collaborations' },
+      '0'
+    );
+
+    const output = await synchronizer.fetchData();
+    expect(output).not.toBeNull();
+
+    const items = output?.items ?? [];
+    expect(items).toHaveLength(2);
+
+    const firstCursor = BigInt(items[0]!.cursor);
+    const secondCursor = BigInt(items[1]!.cursor);
+
+    expect(firstCursor).toBe(BigInt(first.revision));
+    expect(secondCursor).toBe(BigInt(second.revision));
+    expect(firstCursor < secondCursor).toBe(true);
+  });
+});

--- a/apps/server/test/synchronizers/node-updates.test.ts
+++ b/apps/server/test/synchronizers/node-updates.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import { database } from '@colanode/server/data/database';
+import { NodeUpdatesSynchronizer } from '@colanode/server/synchronizers/node-updates';
+import { generateId, IdType } from '@colanode/core';
+import { YDoc } from '@colanode/crdt';
+
+const createNodeUpdate = async (input: {
+  nodeId: string;
+  rootId: string;
+  workspaceId: string;
+  createdBy: string;
+}) => {
+  const ydoc = new YDoc();
+  const data = ydoc.getState();
+
+  return database
+    .insertInto('node_updates')
+    .returningAll()
+    .values({
+      id: generateId(IdType.Update),
+      node_id: input.nodeId,
+      root_id: input.rootId,
+      workspace_id: input.workspaceId,
+      data,
+      created_at: new Date(),
+      created_by: input.createdBy,
+      merged_updates: null,
+    })
+    .executeTakeFirstOrThrow();
+};
+
+describe('NodeUpdatesSynchronizer', () => {
+  it('returns updates in revision order after the cursor', async () => {
+    const rootId = generateId(IdType.Space);
+    const nodeId = generateId(IdType.Page);
+    const workspaceId = generateId(IdType.Workspace);
+    const userId = generateId(IdType.User);
+
+    const first = await createNodeUpdate({
+      nodeId,
+      rootId,
+      workspaceId,
+      createdBy: userId,
+    });
+
+    const second = await createNodeUpdate({
+      nodeId,
+      rootId,
+      workspaceId,
+      createdBy: userId,
+    });
+
+    const synchronizer = new NodeUpdatesSynchronizer(
+      'sync-1',
+      {
+        userId,
+        workspaceId,
+        accountId: generateId(IdType.Account),
+        deviceId: generateId(IdType.Device),
+      },
+      { type: 'node.updates', rootId },
+      '0'
+    );
+
+    const output = await synchronizer.fetchData();
+    expect(output).not.toBeNull();
+
+    const items = output?.items ?? [];
+    expect(items).toHaveLength(2);
+
+    const firstCursor = BigInt(items[0]!.cursor);
+    const secondCursor = BigInt(items[1]!.cursor);
+
+    expect(firstCursor).toBe(BigInt(first.revision));
+    expect(secondCursor).toBe(BigInt(second.revision));
+    expect(firstCursor < secondCursor).toBe(true);
+
+    const afterCursorSync = new NodeUpdatesSynchronizer(
+      'sync-2',
+      {
+        userId,
+        workspaceId,
+        accountId: generateId(IdType.Account),
+        deviceId: generateId(IdType.Device),
+      },
+      { type: 'node.updates', rootId },
+      first.revision.toString()
+    );
+
+    const afterOutput = await afterCursorSync.fetchData();
+    expect(afterOutput?.items).toHaveLength(1);
+    expect(afterOutput?.items[0]?.cursor).toBe(second.revision.toString());
+  });
+});

--- a/apps/server/test/synchronizers/users.test.ts
+++ b/apps/server/test/synchronizers/users.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import { database } from '@colanode/server/data/database';
+import { UserSynchronizer } from '@colanode/server/synchronizers/users';
+import { generateId, IdType, UserStatus } from '@colanode/core';
+
+const createUserRow = async (input: {
+  workspaceId: string;
+  accountId: string;
+  role: string;
+  email: string;
+  name: string;
+  status: UserStatus;
+}) => {
+  return database
+    .insertInto('users')
+    .returningAll()
+    .values({
+      id: generateId(IdType.User),
+      workspace_id: input.workspaceId,
+      account_id: input.accountId,
+      role: input.role,
+      name: input.name,
+      email: input.email,
+      avatar: null,
+      custom_name: null,
+      custom_avatar: null,
+      created_at: new Date(),
+      created_by: input.accountId,
+      status: input.status,
+      max_file_size: '0',
+      storage_limit: '0',
+    })
+    .executeTakeFirstOrThrow();
+};
+
+describe('UserSynchronizer', () => {
+  it('returns users in revision order after the cursor', async () => {
+    const workspaceId = generateId(IdType.Workspace);
+    const accountId = generateId(IdType.Account);
+    const userId = generateId(IdType.User);
+
+    const first = await createUserRow({
+      workspaceId,
+      accountId,
+      role: 'owner',
+      email: 'first@example.com',
+      name: 'First',
+      status: UserStatus.Active,
+    });
+
+    const second = await createUserRow({
+      workspaceId,
+      accountId: generateId(IdType.Account),
+      role: 'collaborator',
+      email: 'second@example.com',
+      name: 'Second',
+      status: UserStatus.Active,
+    });
+
+    const synchronizer = new UserSynchronizer(
+      'sync-users',
+      {
+        userId,
+        workspaceId,
+        accountId,
+        deviceId: generateId(IdType.Device),
+      },
+      { type: 'users' },
+      '0'
+    );
+
+    const output = await synchronizer.fetchData();
+    expect(output).not.toBeNull();
+
+    const items = output?.items ?? [];
+    expect(items).toHaveLength(2);
+
+    const firstCursor = BigInt(items[0]!.cursor);
+    const secondCursor = BigInt(items[1]!.cursor);
+
+    expect(firstCursor).toBe(BigInt(first.revision));
+    expect(secondCursor).toBe(BigInt(second.revision));
+    expect(firstCursor < secondCursor).toBe(true);
+  });
+});

--- a/apps/server/test/tsconfig.json
+++ b/apps/server/test/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Server Tests",
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "baseUrl": "..",
+    "rootDir": ".",
+    "types": ["vitest/globals", "node"]
+  },
+  "include": ["./**/*.ts"]
+}

--- a/apps/server/turbo.json
+++ b/apps/server/turbo.json
@@ -1,6 +1,5 @@
 {
   "extends": ["//"],
-  "globalDependencies": [".env"],
   "tasks": {
     "build": {
       "env": ["DEMO_ENV_VAR"],

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -1,0 +1,25 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+const rootDir = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  root: rootDir,
+  plugins: [tsconfigPaths()],
+  resolve: {
+    alias: {
+      '@colanode/server': path.resolve(rootDir, 'src'),
+      '@colanode/core': path.resolve(rootDir, '../../packages/core/src'),
+      '@colanode/crdt': path.resolve(rootDir, '../../packages/crdt/src'),
+    },
+  },
+  test: {
+    environment: 'node',
+    globalSetup: ['./test/global-setup.ts'],
+    setupFiles: ['./test/setup-env.ts'],
+    include: ['test/**/*.test.ts', 'test/**/*.spec.ts'],
+  },
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "start": "vite --port 4000",
     "build": "vite build && tsc",
     "serve": "vite preview",
-    "test": "vitest run"
+    "test": "vitest --passWithNoTests"
   },
   "dependencies": {
     "@colanode/client": "*",
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.18",
     "@vitejs/plugin-react": "^5.1.2",
+    "jsdom": "^27.4.0",
     "tailwindcss": "^4.1.18",
     "vite": "^7.3.1",
     "vite-plugin-pwa": "^1.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "tsx": "^4.21.0",
         "turbo": "^2.7.3",
         "typescript": "^5.9.3",
-        "vitest": "^3.2.4"
+        "vitest": "^4.0.17"
       }
     },
     "apps/desktop": {
@@ -132,11 +132,16 @@
         "zod": "^4.3.5"
       },
       "devDependencies": {
+        "@testcontainers/postgresql": "^11.11.0",
+        "@testcontainers/redis": "^11.11.0",
         "@types/node": "^25.0.3",
         "@types/nodemailer": "^7.0.4",
         "@types/pg": "^8.16.0",
         "@types/ws": "^8.18.1",
-        "tsup": "^8.5.1"
+        "testcontainers": "^11.11.0",
+        "tsup": "^8.5.1",
+        "vite-tsconfig-paths": "^6.0.4",
+        "vitest": "^4.0.17"
       }
     },
     "apps/web": {
@@ -151,6 +156,7 @@
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.18",
         "@vitejs/plugin-react": "^5.1.2",
+        "jsdom": "^27.4.0",
         "tailwindcss": "^4.1.18",
         "vite": "^7.3.1",
         "vite-plugin-pwa": "^1.2.0"
@@ -170,6 +176,13 @@
         }
       }
     },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
@@ -182,6 +195,82 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.1.tgz",
+      "integrity": "sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "lru-cache": "^11.2.4"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.7.6",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.6.tgz",
+      "integrity": "sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.4"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",
@@ -1361,7 +1450,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -3457,6 +3545,13 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@borewit/text-codec": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.1.tgz",
@@ -3510,6 +3605,141 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.25.tgz",
+      "integrity": "sha512-g0Kw9W3vjx5BEBAF8c5Fm2NcB/Fs8jJXh85aXqwEXiL+tqtOut07TWgyaGzAAfTM+gKckrrncyeGEZPcaRgm2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@dabh/diagnostics": {
@@ -4156,6 +4386,7 @@
       "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^4.1.1",
         "fs-extra": "^9.0.1",
@@ -4171,6 +4402,7 @@
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -5384,6 +5616,24 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.8.0.tgz",
+      "integrity": "sha512-8JPn18Bcp8Uo1T82gR8lh2guEOa5KKU/IEKvvdp0sgmi7coPBWf1Doi1EXsGZb2ehc8ym/StJCjffYV+ne7sXQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@exodus/crypto": "^1.0.0-rc.4"
+      },
+      "peerDependenciesMeta": {
+        "@exodus/crypto": {
+          "optional": true
+        }
       }
     },
     "node_modules/@expo/cli": {
@@ -6853,7 +7103,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
       "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.3",
         "@floating-ui/utils": "^0.2.10"
@@ -6986,6 +7235,58 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/@hookform/resolvers": {
       "version": "5.2.2",
@@ -7687,7 +7988,6 @@
       "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^3.0.1",
         "@inquirer/confirm": "^4.0.1",
@@ -8167,6 +8467,17 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/@listr2/prompt-adapter-inquirer": {
@@ -8666,7 +8977,6 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -9027,6 +9337,80 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -12542,12 +12926,31 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@testcontainers/postgresql": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@testcontainers/postgresql/-/postgresql-11.11.0.tgz",
+      "integrity": "sha512-Og64I/h5LKLVvUTkAcLeTXfFcMhh3dCHCypN3Uzd+tQMd70SpCfQ0LCP9v/U+MS7JBRzU9EmqhUFkTOm4hyZWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "testcontainers": "^11.11.0"
+      }
+    },
+    "node_modules/@testcontainers/redis": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@testcontainers/redis/-/redis-11.11.0.tgz",
+      "integrity": "sha512-IaDPNd1jRkshwJ69D7Nc3OTt5QQG1d4G1TZILSQ7gAVr4OqAJxoA9pV73ZvKIF/8LwxDDg136ApPlU9PcFtIKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "testcontainers": "^11.11.0"
+      }
+    },
     "node_modules/@tiptap/core": {
       "version": "3.15.3",
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.15.3.tgz",
       "integrity": "sha512-bmXydIHfm2rEtGju39FiQNfzkFx9CDvJe+xem1dgEZ2P6Dj7nQX9LnA1ZscW7TuzbBRkL5p3dwuBIi3f62A66A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -12847,7 +13250,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.15.3.tgz",
       "integrity": "sha512-Zm1BaU1TwFi3CQiisxjgnzzIus+q40bBKWLqXf6WEaus8Z6+vo1MT2pU52dBCMIRaW9XNDq3E5cmGtMc1AlveA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -13215,7 +13617,6 @@
       "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/ms": "*"
       }
@@ -13233,6 +13634,29 @@
       "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/docker-modem": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
+      "integrity": "sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
+    "node_modules/@types/dockerode": {
+      "version": "3.3.47",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.47.tgz",
+      "integrity": "sha512-ShM1mz7rCjdssXt7Xz0u1/R2BJC7piWa3SJpUBiVjCf2A3XNn4cP6pUVaD8bLanpPVVn4IKzJuw3dOvkJ8IbYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/docker-modem": "*",
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
     },
     "node_modules/@types/electron-squirrel-startup": {
       "version": "1.0.2",
@@ -13302,6 +13726,7 @@
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
       "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "*"
       }
@@ -13461,7 +13886,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -13471,7 +13895,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -13509,6 +13932,43 @@
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
       "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ssh2": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+      "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18"
+      }
+    },
+    "node_modules/@types/ssh2-streams": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@types/ssh2-streams/-/ssh2-streams-0.1.13.tgz",
+      "integrity": "sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true,
       "license": "MIT"
     },
@@ -13553,7 +14013,8 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -13650,7 +14111,6 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -14002,39 +14462,40 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.17.tgz",
+      "integrity": "sha512-mEoqP3RqhKlbmUmntNDDCJeTDavDR+fVYkSOw8qRwJFaW/0/5zA9zFeTrHqNtcmwh6j26yMmwx2PqUDPzt5ZAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/spy": "4.0.17",
+        "@vitest/utils": "4.0.17",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.17.tgz",
+      "integrity": "sha512-+ZtQhLA3lDh1tI2wxe3yMsGzbp7uuJSWBM1iTIKCbppWTSBN09PUC+L+fyNlQApQoR+Ps8twt2pbSSXg2fQVEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "4.0.17",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
+        "magic-string": "^0.30.21"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0-0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -14046,42 +14507,41 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.17.tgz",
+      "integrity": "sha512-Ah3VAYmjcEdHg6+MwFE17qyLqBHZ+ni2ScKCiW2XrlSBV4H3Z7vYfPfz7CWQ33gyu76oc0Ai36+kgLU3rfF4nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^2.0.0"
+        "tinyrainbow": "^3.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.17.tgz",
+      "integrity": "sha512-JmuQyf8aMWoo/LmNFppdpkfRVHJcsgzkbCA+/Bk7VfNH7RE6Ut2qxegeyx2j3ojtJtKIbIGy3h+KxGfYfk28YQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
-        "pathe": "^2.0.3",
-        "strip-literal": "^3.0.0"
+        "@vitest/utils": "4.0.17",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.17.tgz",
+      "integrity": "sha512-npPelD7oyL+YQM2gbIYvlavlMVWUfNNGZPcu0aEUQXt7FXTuqhmgiYupPnAanhKvyP6Srs2pIbWo30K0RbDtRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "magic-string": "^0.30.17",
+        "@vitest/pretty-format": "4.0.17",
+        "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -14089,28 +14549,24 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.17.tgz",
+      "integrity": "sha512-I1bQo8QaP6tZlTomQNWKJE6ym4SHf3oLS7ceNjozxxgzavRAgZDc06T7kD8gb9bXKEgcLNt00Z+kZO6KaJ62Ew==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.17.tgz",
+      "integrity": "sha512-RG6iy+IzQpa9SB8HAFHJ9Y+pTzI+h8553MrciN9eC6TFBErqrQaTas4vG+MVj8S4uKk8uTT2p0vgZPnTdxd96w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/pretty-format": "4.0.17",
+        "tinyrainbow": "^3.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -14353,7 +14809,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -14603,6 +15058,215 @@
         "node": ">=8.5"
       }
     },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/archiver-utils/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/archiver/node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/archiver/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/archiver/node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/archiver/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/archiver/node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -14808,6 +15472,16 @@
       "integrity": "sha512-usgMoyXjMbx/ZPdzTSXExhMPur2FTdz/Vo5PVx2gIaBcdAAJNOFlsdgqveM8Cff7W0v+xrf9BwjOV26JSAF9qA==",
       "license": "MIT"
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "node_modules/asn1js": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
@@ -14937,6 +15611,21 @@
       "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz",
       "integrity": "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==",
       "license": "MIT"
+    },
+    "node_modules/b4a": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
     },
     "node_modules/b64-lite": {
       "version": "1.4.0",
@@ -15189,6 +15878,103 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.2.tgz",
+      "integrity": "sha512-veTnRzkb6aPHOvSKIOy60KzURfBdUflr5VReI+NSaPL6xf+XLdONQgZgpYvUuZLVQ8dCqxpBAudaOM1+KpAUxw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
+      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
+      "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.21.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
+      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
     "node_modules/base-64": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
@@ -15232,6 +16018,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
       }
     },
     "node_modules/before-after-hook": {
@@ -15282,6 +16078,16 @@
       },
       "engines": {
         "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/big-integer": {
@@ -15420,7 +16226,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -15503,6 +16308,16 @@
         "node": ">=6.14.2"
       }
     },
+    "node_modules/buildcheck": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+      "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/bullmq": {
       "version": "5.66.4",
       "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.66.4.tgz",
@@ -15575,6 +16390,16 @@
       },
       "peerDependencies": {
         "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/byline": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/bytes": {
@@ -15839,18 +16664,11 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
       "engines": {
         "node": ">=18"
       }
@@ -15877,16 +16695,6 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/check-error": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      }
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -16369,6 +17177,78 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/compress-commons/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/compress-commons/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/compress-commons/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -16520,6 +17400,90 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
@@ -16657,6 +17621,53 @@
       "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
       "license": "MIT"
     },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/cssstyle/node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -16668,6 +17679,57 @@
       "resolved": "https://registry.npmjs.org/custom-error-instance/-/custom-error-instance-2.1.1.tgz",
       "integrity": "sha512-p6JFxJc3M4OTD2li2qaHkDCw9SfMw82Ldr6OC9Je1aXiGfhx2W8p3GaoeaGrPJTUN9NirTM/KTxHWMUdR1rsUg==",
       "license": "ISC"
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
+      "integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -16756,6 +17818,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -16781,16 +17850,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/deep-extend": {
@@ -16975,6 +18034,7 @@
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
       "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.0"
       },
@@ -17036,6 +18096,68 @@
         "@react-dnd/asap": "^5.0.1",
         "@react-dnd/invariant": "^4.0.1",
         "redux": "^4.2.0"
+      }
+    },
+    "node_modules/docker-compose": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-1.3.0.tgz",
+      "integrity": "sha512-7Gevk/5eGD50+eMD+XDnFnOrruFkL0kSd7jEG4cjmqweDSUhB7i0g8is/nBdVpl+Bx338SqIB2GLKm32M+Vs6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/docker-modem": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.6.tgz",
+      "integrity": "sha512-ens7BiayssQz/uAxGzH8zGXCtiV24rRWXdjNha5V4zSOcxmAZsfGVm/PPFbwQdqEkDnhG+SyR9E3zSHUbOKXBQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "readable-stream": "^3.5.0",
+        "split-ca": "^1.0.1",
+        "ssh2": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/dockerode": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.9.tgz",
+      "integrity": "sha512-iND4mcOWhPaCNh54WmK/KoSb35AFqPAUWFMffTQcp52uQt36b5uNwEJTSXntJZBbeGad72Crbi/hvDIv6us/6Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@balena/dockerignore": "^1.0.2",
+        "@grpc/grpc-js": "^1.11.1",
+        "@grpc/proto-loader": "^0.7.13",
+        "docker-modem": "^5.0.6",
+        "protobufjs": "^7.3.2",
+        "tar-fs": "^2.1.4",
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/dockerode/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/doctrine": {
@@ -18167,7 +19289,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -18237,7 +19358,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -18728,6 +19848,16 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/exec-async": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/exec-async/-/exec-async-2.2.0.tgz",
@@ -18857,7 +19987,6 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.31.tgz",
       "integrity": "sha512-kQ3RDqA/a59I7y+oqQGyrPbbYlgPMUdKBOgvFLpoHbD2bCM+F75i4N0mUijy7dG5F/CUCu2qHmGGUCXBbMDkCg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.21",
@@ -18973,7 +20102,6 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.10.tgz",
       "integrity": "sha512-UqyNaaLKRpj4pKAP4HZSLnuDQqueaO5tB1c/NWu5vh1/LF9ulItyyg2kF/IpeOp0DeOLk0GY0HrIXaKUMrwB+Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -19189,6 +20317,13 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -19336,7 +20471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@fastify/ajv-compiler": "^4.0.0",
         "@fastify/error": "^4.0.0",
@@ -20128,6 +21262,19 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/get-port": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
+      "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -20339,6 +21486,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/google-auth-library": {
       "version": "9.15.1",
@@ -20598,6 +21752,19 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/html-entities": {
       "version": "2.6.0",
@@ -21287,6 +22454,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
@@ -21891,6 +23065,83 @@
       "integrity": "sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==",
       "license": "0BSD"
     },
+    "node_modules/jsdom": {
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -21957,6 +23208,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-resolver/-/json-schema-resolver-3.0.0.tgz",
       "integrity": "sha512-HqMnbz0tz2DaEJ3ntsqtx3ezzZyDE7G56A/pPY/NGmrPu76UzsWquOpHFRAf5beTNXoH2LU5cQePVvRli1nchA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.1.1",
         "fast-uri": "^3.0.5",
@@ -22127,6 +23379,59 @@
       "license": "MIT",
       "bin": {
         "lan-network": "dist/lan-network-cli.js"
+      }
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/leven": {
@@ -22710,6 +24015,13 @@
         "lodash._basetostring": "~4.12.0"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -22914,6 +24226,13 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -22925,13 +24244,6 @@
       "bin": {
         "loose-envify": "cli.js"
       }
-    },
-    "node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
@@ -24480,6 +25792,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -24845,6 +26168,32 @@
         "node": ">=10"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -24932,16 +26281,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
-    },
     "node_modules/pe-library": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-1.0.1.tgz",
@@ -24969,7 +26308,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -25193,7 +26531,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -25434,6 +26771,16 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -25556,6 +26903,23 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
+    "node_modules/properties-reader": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-2.3.0.tgz",
+      "integrity": "sha512-z597WicA7nDZxK12kZqHr2TcvwNU1GCfA5UwfDY/HDp3hXPoPlb5rlEx9bwGTiJnc0OqbBTkU975jDToth8Gxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mkdirp": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/properties?sponsor=1"
+      }
+    },
     "node_modules/prosemirror-changeset": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.3.1.tgz",
@@ -25668,7 +27032,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -25698,7 +27061,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -25747,11 +27109,35 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.4.tgz",
       "integrity": "sha512-WkKgnyjNncri03Gjaz3IFWvCAE94XoiEgvtr0/r2Xw7R8/IjK3sKLSiDoCHWcsXSAinVaKlGRZDvMCsF1kbzjA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/pump": {
@@ -25939,7 +27325,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -26049,7 +27434,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -26100,7 +27484,6 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.83.1.tgz",
       "integrity": "sha512-mL1q5HPq5cWseVhWRLl+Fwvi5z1UO+3vGOpjr+sHFwcUletPRZ5Kv+d0tUfqHmvi73/53NjlQqX1Pyn4GguUfA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.83.1",
@@ -26204,7 +27587,6 @@
       "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.16.0.tgz",
       "integrity": "sha512-Nh13xKZWW35C0dbOskD7OX01nQQavOzHbCw9XoZmar4eXCo7AvrYJ0jlUfRVVIJzqINxHlpECYLdmAdFsl9xDA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^4.0.0",
         "invariant": "2.2.4"
@@ -26309,7 +27691,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
       "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -26510,6 +27891,29 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/readdirp": {
@@ -26989,7 +28393,6 @@
       "integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -27178,6 +28581,19 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -27210,7 +28626,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -27423,7 +28838,6 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.4.2.tgz",
       "integrity": "sha512-N3HEHRCZYn3cQbsC4B5ldj9j+tHdf4JZoYPlcI4rRYu0Xy4qN8MQf1Z08EibzB0WpgRG5BGK08FTrmM66eSzKQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -27974,6 +29388,13 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/split-ca": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+      "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -28001,6 +29422,46 @@
       },
       "engines": {
         "node": ">=20.16.0"
+      }
+    },
+    "node_modules/ssh-remote-port-forward": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ssh-remote-port-forward/-/ssh-remote-port-forward-1.0.4.tgz",
+      "integrity": "sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ssh2": "^0.5.48",
+        "ssh2": "^1.4.0"
+      }
+    },
+    "node_modules/ssh-remote-port-forward/node_modules/@types/ssh2": {
+      "version": "0.5.52",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.52.tgz",
+      "integrity": "sha512-lbLLlXxdCZOSJMCInKH2+9V/77ET2J6NPQHpFI0kda61Dd1KglJs+fPQBchizmzYSOJBgdTajhPqBO1xxLywvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ssh2-streams": "*"
+      }
+    },
+    "node_modules/ssh2": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
       }
     },
     "node_modules/ssri": {
@@ -28152,6 +29613,18 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
       "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
       "license": "MIT"
+    },
+    "node_modules/streamx": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
+      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -28423,26 +29896,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/strip-literal": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^9.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/strip-literal/node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/strip-outer": {
       "version": "1.0.1",
@@ -28799,6 +30252,13 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
       "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
       "license": "CC0-1.0"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tabbable": {
       "version": "6.4.0",
@@ -29267,6 +30727,87 @@
         "node": "*"
       }
     },
+    "node_modules/testcontainers": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-11.11.0.tgz",
+      "integrity": "sha512-nKTJn3n/gkyGg/3SVkOwX+isPOGSHlfI+CWMobSmvQrsj7YW01aWvl2pYIfV4LMd+C8or783yYrzKSK2JlP+Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@balena/dockerignore": "^1.0.2",
+        "@types/dockerode": "^3.3.47",
+        "archiver": "^7.0.1",
+        "async-lock": "^1.4.1",
+        "byline": "^5.0.0",
+        "debug": "^4.4.3",
+        "docker-compose": "^1.3.0",
+        "dockerode": "^4.0.9",
+        "get-port": "^7.1.0",
+        "proper-lockfile": "^4.1.2",
+        "properties-reader": "^2.3.0",
+        "ssh-remote-port-forward": "^1.0.4",
+        "tar-fs": "^3.1.1",
+        "tmp": "^0.2.5",
+        "undici": "^7.16.0"
+      }
+    },
+    "node_modules/testcontainers/node_modules/tar-fs": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/testcontainers/node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/testcontainers/node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/testcontainers/node_modules/undici": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
+      "integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
     "node_modules/text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
@@ -29366,30 +30907,10 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinypool": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
     "node_modules/tinyrainbow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tinyspy": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -29400,6 +30921,26 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/tiptap-extension-auto-joiner/-/tiptap-extension-auto-joiner-0.1.3.tgz",
       "integrity": "sha512-nY3aKeCpVb2WjjVEZkLtEqxsK3KU1zGioyglMhK1sUFNjKDccOfRyz/YDKrHRAVsKJPGnk2A8VA1827iGEAXWQ==",
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
+      "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.19"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
+      "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tmp": {
@@ -29513,6 +31054,19 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -29585,6 +31139,27 @@
       "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.9.0.tgz",
       "integrity": "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==",
       "license": "MIT"
+    },
+    "node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -29684,7 +31259,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -29853,6 +31427,13 @@
         "url": "https://github.com/sponsors/Wombosvideo"
       }
     },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "dev": true,
+      "license": "Unlicense"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -29971,7 +31552,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -30428,7 +32008,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -30498,29 +32077,6 @@
         }
       }
     },
-    "node_modules/vite-node": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.4.1",
-        "es-module-lexer": "^1.7.0",
-        "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/vite-plugin-pwa": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/vite-plugin-pwa/-/vite-plugin-pwa-1.2.0.tgz",
@@ -30582,52 +32138,72 @@
         "vite": "^5.4.11 || ^6.0.0 || ^7.0.0"
       }
     },
-    "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+    "node_modules/vite-tsconfig-paths": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-6.0.4.tgz",
+      "integrity": "sha512-iIsEJ+ek5KqRTK17pmxtgIxXtqr3qDdE6OxrP9mVeGhVDNXRJTKN/l9oMbujTQNzMLe6XZ8qmpztfbkPu2TiFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "debug": "^4.4.1",
-        "expect-type": "^1.2.1",
-        "magic-string": "^0.30.17",
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3",
+        "vite": "*"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.17.tgz",
+      "integrity": "sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.17",
+        "@vitest/mocker": "4.0.17",
+        "@vitest/pretty-format": "4.0.17",
+        "@vitest/runner": "4.0.17",
+        "@vitest/snapshot": "4.0.17",
+        "@vitest/spy": "4.0.17",
+        "@vitest/utils": "4.0.17",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.2",
-        "std-env": "^3.9.0",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.14",
-        "tinypool": "^1.1.1",
-        "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.4",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.17",
+        "@vitest/browser-preview": "4.0.17",
+        "@vitest/browser-webdriverio": "4.0.17",
+        "@vitest/ui": "4.0.17",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -30635,13 +32211,19 @@
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@types/debug": {
+        "@opentelemetry/api": {
           "optional": true
         },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser": {
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
           "optional": true
         },
         "@vitest/ui": {
@@ -30655,6 +32237,16 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/vlq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
@@ -30666,6 +32258,19 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/walker": {
       "version": "1.0.8",
@@ -30819,6 +32424,16 @@
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -31207,7 +32822,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -31334,7 +32948,6 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -31653,7 +33266,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -31692,6 +33304,16 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xml2js": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.0.tgz",
@@ -31722,6 +33344,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xpath": {
       "version": "0.0.34",
@@ -31880,12 +33509,68 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/zip-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/zip-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/zod": {
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "tsx": "^4.21.0",
     "turbo": "^2.7.3",
     "typescript": "^5.9.3",
-    "vitest": "^3.2.4"
+    "vitest": "^4.0.17"
   },
   "dependencies": {
     "debug": "^4.4.3",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "compile": "tsc --noEmit",
-    "test": "vitest",
+    "test": "vitest --passWithNoTests",
     "lint": "eslint . --max-warnings 0",
     "build": "tsc",
     "coverage": "vitest run --coverage "

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "compile": "tsc --noEmit",
-    "test": "vitest",
+    "test": "vitest --passWithNoTests",
     "lint": "eslint src --ext .ts --max-warnings 0",
     "build": "tsc",
     "coverage": "vitest run --coverage "

--- a/packages/crdt/package.json
+++ b/packages/crdt/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "compile": "tsc --noEmit",
-    "test": "vitest",
+    "test": "vitest --passWithNoTests",
     "lint": "eslint . --max-warnings 0",
     "build": "tsc",
     "coverage": "vitest run --coverage "

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "compile": "tsc --noEmit",
-    "test": "vitest",
+    "test": "vitest --passWithNoTests",
     "lint": "eslint . --max-warnings 0",
     "build": "tsc",
     "coverage": "vitest run --coverage "

--- a/turbo.json
+++ b/turbo.json
@@ -2,6 +2,10 @@
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": [".env", "**/.env.*local"],
   "tasks": {
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**", "out/**", "assets/**"]


### PR DESCRIPTION
## Summary
- Add a Vitest + Testcontainers harness for `apps/server` with Postgres (pgvector) + Redis.
- Add initial API, synchronizer, and utility tests plus reusable seed/app helpers.
- Align monorepo test/dev scripts for Turbo and bump Vitest to v4.
- Expand `apps/server/README.md` with requirements, config, code map, and test info.

## What changed

### Server test infrastructure
- `apps/server/vitest.config.ts` and `apps/server/test/tsconfig.json` for Vitest + TS aliases.
- `apps/server/test/global-setup.ts` starts Postgres/Redis containers and writes a test config.
- `apps/server/test/setup-env.ts` loads env/config before server modules import.
- `apps/server/test/helpers/*` for app bootstrapping and seed data.
- Test structure/naming: centralized under `apps/server/test/{api,synchronizers,lib}` with domain‑grouped files (auth, account, workspace, files, mutations).

### Initial server tests
- API coverage: auth login, token lifecycle, workspace access, readonly enforcement, role/status updates, invite permissions, mutation idempotency, file upload/download, delete cascade, account sync.
- Synchronizers: users, collaborations, node updates.
- Utility: lib utils.

### Monorepo plumbing
- Vitest upgraded to v4.0.17 (root + server).
- Package test scripts use `vitest --passWithNoTests` to keep `turbo run test` green when packages have no tests yet.
- `apps/web` adds `jsdom` devDependency for Vitest compatibility.
- `turbo.json` marks `dev` as persistent/non‑cached; `apps/server/turbo.json` removes `globalDependencies` to avoid Turbo parsing issues.

### Docs
- `apps/server/README.md` now includes requirements, local setup, config model, code map, and testing notes.

## How to run
- Server tests: `cd apps/server && npm run test` (requires Docker).
- Optional monorepo test runner: `npm run test`.

## Notes
- Tests are integration‑style via `fastify.inject()` (no ports bound).
- Testcontainers uses `pgvector/pg17` and Redis; jobs/logging are disabled in the test config.
- One test mocks `jobService.addJob` to avoid enqueueing background jobs (delete cascade).
