### PR TITLE
Mobile: QoL polish sprint — toast, haptics, chat sorting, skeletons

### DIFF
--- a/apps/mobile/app/(app)/(chats)/index.tsx
+++ b/apps/mobile/app/(app)/(chats)/index.tsx
@@ -6,6 +6,8 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { LocalChatNode } from '@colanode/client/types/nodes';
 import { ChatListItem } from '@colanode/mobile/components/chats/chat-list-item';
 import { EmptyState } from '@colanode/mobile/components/ui/empty-state';
+import { ListSeparator } from '@colanode/mobile/components/ui/list-separator';
+import { SkeletonList } from '@colanode/mobile/components/ui/skeleton';
 import { useTheme } from '@colanode/mobile/contexts/theme';
 import { useWorkspace } from '@colanode/mobile/contexts/workspace';
 import { useLiveQuery } from '@colanode/mobile/hooks/use-live-query';
@@ -21,7 +23,7 @@ export default function ChatsScreen() {
   const { data: chats, isLoading, refetch, isRefetching } = useNodeListQuery<LocalChatNode>(
     userId,
     [{ field: ['type'], operator: 'eq', value: 'chat' }],
-    [{ field: ['createdAt'], direction: 'desc', nulls: 'last' }]
+    [{ field: ['updatedAt'], direction: 'desc', nulls: 'last' }]
   );
 
   const { data: users } = useLiveQuery({
@@ -57,9 +59,7 @@ export default function ChatsScreen() {
             unreadCount={getNodeUnreadCount(radarData, userId, item.id)}
           />
         )}
-        ItemSeparatorComponent={() => (
-          <View style={[styles.separator, { backgroundColor: colors.listSeparator }]} />
-        )}
+        ItemSeparatorComponent={() => <ListSeparator marginLeft={72} />}
         contentContainerStyle={styles.list}
         refreshControl={
           <RefreshControl
@@ -69,12 +69,14 @@ export default function ChatsScreen() {
           />
         }
         ListEmptyComponent={
-          !isLoading ? (
+          isLoading ? (
+            <SkeletonList />
+          ) : (
             <EmptyState
               title="No chats yet"
               subtitle="Start a new conversation"
             />
-          ) : null
+          )
         }
         ListFooterComponent={
           chats && chats.length > 0 && chats.length <= 3 ? (
@@ -130,10 +132,6 @@ const styles = StyleSheet.create({
   },
   fabPressed: {
     opacity: 0.8,
-  },
-  separator: {
-    height: StyleSheet.hairlineWidth,
-    marginLeft: 72,
   },
   list: {
     flexGrow: 1,

--- a/apps/mobile/app/(app)/(home)/index.tsx
+++ b/apps/mobile/app/(app)/(home)/index.tsx
@@ -33,7 +33,7 @@ export default function HomeScreen() {
   const { data: recentChats, refetch: refetchChats, isRefetching: isRefetchingChats, isLoading: chatsLoading } = useNodeListQuery<LocalChatNode>(
     userId,
     [{ field: ['type'], operator: 'eq', value: 'chat' }],
-    [{ field: ['createdAt'], direction: 'desc', nulls: 'last' }],
+    [{ field: ['updatedAt'], direction: 'desc', nulls: 'last' }],
     3
   );
 
@@ -135,12 +135,7 @@ export default function HomeScreen() {
         >
           <Feather name="layers" size={20} color={colors.primary} />
           <Text style={[styles.quickActionText, { color: colors.text }]} numberOfLines={1}>
-            {(() => {
-              const name = recentSpaceItems[0]?.name;
-              if (!name) return 'Spaces';
-              const words = name.trim().split(/\s+/);
-              return words.length > 2 ? words.slice(0, 2).join(' ') + '...' : name;
-            })()}
+            Spaces
           </Text>
         </Pressable>
       </View>
@@ -196,7 +191,7 @@ export default function HomeScreen() {
             >
               <UserAvatar
                 name={space.name ?? 'Space'}
-                avatar={null}
+                avatar={space.avatar ?? null}
                 size={40}
               />
               <View style={styles.spaceInfo}>

--- a/apps/mobile/app/(app)/(settings)/account.tsx
+++ b/apps/mobile/app/(app)/(settings)/account.tsx
@@ -1,7 +1,6 @@
 import { useRouter } from 'expo-router';
 import { useEffect, useState } from 'react';
 import {
-  Alert,
   KeyboardAvoidingView,
   Platform,
   ScrollView,
@@ -15,6 +14,7 @@ import { AvatarPicker } from '@colanode/mobile/components/avatars/avatar-picker'
 import { BackButton } from '@colanode/mobile/components/ui/back-button';
 import { Button } from '@colanode/mobile/components/ui/button';
 import { TextInput } from '@colanode/mobile/components/ui/text-input';
+import { useToast } from '@colanode/mobile/components/ui/toast';
 import { useTheme } from '@colanode/mobile/contexts/theme';
 import { useWorkspace } from '@colanode/mobile/contexts/workspace';
 import { useLiveQuery } from '@colanode/mobile/hooks/use-live-query';
@@ -27,6 +27,7 @@ export default function AccountSettingsScreen() {
   const { accountId } = useWorkspace();
   const { mutate, isPending } = useMutation();
   const { mutate: mutateAvatar } = useMutation();
+  const toast = useToast();
 
   const { data: accounts } = useLiveQuery({ type: 'account.list' });
   const account = (
@@ -60,10 +61,10 @@ export default function AccountSettingsScreen() {
         avatar: undefined,
       },
       onSuccess() {
-        Alert.alert('Success', 'Profile updated');
+        toast.show('Profile updated', 'success');
       },
       onError(err) {
-        Alert.alert('Error', err.message);
+        toast.show(err.message);
       },
     });
   };

--- a/apps/mobile/app/(app)/(settings)/invite.tsx
+++ b/apps/mobile/app/(app)/(settings)/invite.tsx
@@ -16,6 +16,7 @@ import { hasWorkspaceRole, WorkspaceRole } from '@colanode/core';
 import { BackButton } from '@colanode/mobile/components/ui/back-button';
 import { Button } from '@colanode/mobile/components/ui/button';
 import { TextInput } from '@colanode/mobile/components/ui/text-input';
+import { useToast } from '@colanode/mobile/components/ui/toast';
 import { useTheme } from '@colanode/mobile/contexts/theme';
 import { useWorkspace } from '@colanode/mobile/contexts/workspace';
 import { useMutation } from '@colanode/mobile/hooks/use-mutation';
@@ -37,6 +38,7 @@ export default function InviteScreen() {
   const { userId, role: workspaceRole } = useWorkspace();
   const canInvite = hasWorkspaceRole(workspaceRole, 'admin');
   const { mutate, isPending } = useMutation();
+  const toast = useToast();
 
   const [email, setEmail] = useState('');
   const [emails, setEmails] = useState<string[]>([]);
@@ -120,7 +122,7 @@ export default function InviteScreen() {
         }
       },
       onError(err) {
-        Alert.alert('Error', err.message);
+        toast.show(err.message);
       },
     });
   };

--- a/apps/mobile/app/(app)/(settings)/workspace.tsx
+++ b/apps/mobile/app/(app)/(settings)/workspace.tsx
@@ -1,7 +1,6 @@
 import { useRouter } from 'expo-router';
 import { useEffect, useState } from 'react';
 import {
-  Alert,
   KeyboardAvoidingView,
   Platform,
   ScrollView,
@@ -15,6 +14,7 @@ import { AvatarPicker } from '@colanode/mobile/components/avatars/avatar-picker'
 import { BackButton } from '@colanode/mobile/components/ui/back-button';
 import { Button } from '@colanode/mobile/components/ui/button';
 import { TextInput } from '@colanode/mobile/components/ui/text-input';
+import { useToast } from '@colanode/mobile/components/ui/toast';
 import { useTheme } from '@colanode/mobile/contexts/theme';
 import { useWorkspace } from '@colanode/mobile/contexts/workspace';
 import { useMutation } from '@colanode/mobile/hooks/use-mutation';
@@ -26,6 +26,7 @@ export default function WorkspaceSettingsScreen() {
   const { userId, accountId, workspace, role } = useWorkspace();
   const { mutate, isPending } = useMutation();
   const { mutate: mutateAvatar } = useMutation();
+  const toast = useToast();
 
   const [name, setName] = useState(workspace.name);
   const [description, setDescription] = useState(
@@ -57,10 +58,10 @@ export default function WorkspaceSettingsScreen() {
         avatar: workspace.avatar ?? null,
       },
       onSuccess() {
-        Alert.alert('Success', 'Workspace updated');
+        toast.show('Workspace updated', 'success');
       },
       onError(err) {
-        Alert.alert('Error', err.message);
+        toast.show(err.message);
       },
     });
   };

--- a/apps/mobile/app/(app)/(spaces)/create-space.tsx
+++ b/apps/mobile/app/(app)/(spaces)/create-space.tsx
@@ -1,7 +1,6 @@
 import { useRouter } from 'expo-router';
 import { useState } from 'react';
 import {
-  Alert,
   KeyboardAvoidingView,
   Platform,
   Pressable,
@@ -13,6 +12,7 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { generateId, hasWorkspaceRole, IdType } from '@colanode/core';
+import { useToast } from '@colanode/mobile/components/ui/toast';
 import { useTheme } from '@colanode/mobile/contexts/theme';
 import { useWorkspace } from '@colanode/mobile/contexts/workspace';
 import { useMutation } from '@colanode/mobile/hooks/use-mutation';
@@ -23,6 +23,7 @@ export default function CreateSpaceScreen() {
   const { mutate, isPending } = useMutation();
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
+  const toast = useToast();
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const canCreateSpace = hasWorkspaceRole(role, 'collaborator');
@@ -50,7 +51,7 @@ export default function CreateSpaceScreen() {
         router.back();
       },
       onError(error) {
-        Alert.alert('Error', error.message);
+        toast.show(error.message);
       },
     });
   };

--- a/apps/mobile/app/(app)/(spaces)/file/[fileId].tsx
+++ b/apps/mobile/app/(app)/(spaces)/file/[fileId].tsx
@@ -16,7 +16,7 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { LocalFileNode } from '@colanode/client/types/nodes';
-import { LoadingScreen } from '@colanode/mobile/components/loading-screen';
+import { SkeletonFilePreview } from '@colanode/mobile/components/ui/skeleton';
 import { BackButton } from '@colanode/mobile/components/ui/back-button';
 import { useAppService } from '@colanode/mobile/contexts/app-service';
 import { useTheme } from '@colanode/mobile/contexts/theme';
@@ -179,7 +179,7 @@ export default function FileScreen() {
   };
 
   if (isLoading) {
-    return <LoadingScreen />;
+    return <SkeletonFilePreview />;
   }
 
   const isImage = file?.subtype === 'image';

--- a/apps/mobile/app/(app)/(spaces)/index.tsx
+++ b/apps/mobile/app/(app)/(spaces)/index.tsx
@@ -7,6 +7,8 @@ import { LocalSpaceNode } from '@colanode/client/types/nodes';
 import { hasWorkspaceRole } from '@colanode/core';
 import { SpaceListItem } from '@colanode/mobile/components/spaces/space-list-item';
 import { EmptyState } from '@colanode/mobile/components/ui/empty-state';
+import { ListSeparator } from '@colanode/mobile/components/ui/list-separator';
+import { SkeletonList } from '@colanode/mobile/components/ui/skeleton';
 import { useTheme } from '@colanode/mobile/contexts/theme';
 import { useWorkspace } from '@colanode/mobile/contexts/workspace';
 import { useNodeListQuery } from '@colanode/mobile/hooks/use-node-list-query';
@@ -43,9 +45,7 @@ export default function SpacesScreen() {
             }
           />
         )}
-        ItemSeparatorComponent={() => (
-          <View style={[styles.separator, { backgroundColor: colors.listSeparator }]} />
-        )}
+        ItemSeparatorComponent={() => <ListSeparator marginLeft={68} />}
         contentContainerStyle={styles.list}
         refreshControl={
           <RefreshControl
@@ -55,7 +55,9 @@ export default function SpacesScreen() {
           />
         }
         ListEmptyComponent={
-          !isLoading ? (
+          isLoading ? (
+            <SkeletonList />
+          ) : (
             <EmptyState
               title="No spaces yet"
               subtitle={
@@ -64,7 +66,7 @@ export default function SpacesScreen() {
                   : 'No spaces are available to you yet'
               }
             />
-          ) : null
+          )
         }
         ListFooterComponent={
           canCreateSpace && spaces && spaces.length > 0 && spaces.length <= 3 ? (
@@ -122,10 +124,6 @@ const styles = StyleSheet.create({
   },
   fabPressed: {
     opacity: 0.8,
-  },
-  separator: {
-    height: StyleSheet.hairlineWidth,
-    marginLeft: 68,
   },
   list: {
     flexGrow: 1,

--- a/apps/mobile/app/(app)/(spaces)/page/[pageId]/index.tsx
+++ b/apps/mobile/app/(app)/(spaces)/page/[pageId]/index.tsx
@@ -14,7 +14,7 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { LocalPageNode } from '@colanode/client/types/nodes';
-import { LoadingScreen } from '@colanode/mobile/components/loading-screen';
+import { SkeletonPage } from '@colanode/mobile/components/ui/skeleton';
 import { RenameNodeSheet } from '@colanode/mobile/components/nodes/rename-node-sheet';
 import { PageBlockTypeSheet } from '@colanode/mobile/components/pages/page-block-type-sheet';
 import { PageEditorToolbar } from '@colanode/mobile/components/pages/page-editor-toolbar';
@@ -132,7 +132,7 @@ export default function PageScreen() {
   const showToolbar = (keyboardHeight > 0 && editorFocused && canEdit) || showBlockTypes;
 
   if (isLoading) {
-    return <LoadingScreen />;
+    return <SkeletonPage />;
   }
 
   return (

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -14,6 +14,7 @@ import {
   useAppService,
 } from '@colanode/mobile/contexts/app-service';
 import { ThemeProvider, useTheme } from '@colanode/mobile/contexts/theme';
+import { ToastProvider } from '@colanode/mobile/components/ui/toast';
 import { copyAssets } from '@colanode/mobile/lib/assets';
 import { buildQueryClient } from '@colanode/mobile/lib/query-client';
 import { MobileFileSystem } from '@colanode/mobile/services/file-system';
@@ -121,13 +122,15 @@ export default function RootLayout() {
   return (
     <ThemeProvider>
       <ThemeStatusBar />
-      <AppServiceContext.Provider value={{ appService }}>
-        <QueryClientProvider client={queryClient}>
-          <ErrorBoundary>
-            <RootNavigator />
-          </ErrorBoundary>
-        </QueryClientProvider>
-      </AppServiceContext.Provider>
+      <ToastProvider>
+        <AppServiceContext.Provider value={{ appService }}>
+          <QueryClientProvider client={queryClient}>
+            <ErrorBoundary>
+              <RootNavigator />
+            </ErrorBoundary>
+          </QueryClientProvider>
+        </AppServiceContext.Provider>
+      </ToastProvider>
     </ThemeProvider>
   );
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -29,6 +29,7 @@
     "expo-device": "~8.0.10",
     "expo-document-picker": "^55.0.8",
     "expo-file-system": "~19.0.21",
+    "expo-haptics": "~15.0.8",
     "expo-image-picker": "~17.0.10",
     "expo-linking": "~8.0.11",
     "expo-router": "~6.0.23",

--- a/apps/mobile/src/components/chats/chat-list-item.tsx
+++ b/apps/mobile/src/components/chats/chat-list-item.tsx
@@ -52,11 +52,11 @@ export const ChatListItem = memo(({
     >
       <UserAvatar name={displayName} avatar={otherUser?.avatar ?? null} size={44} />
       <View style={styles.info}>
-        <Text style={[styles.name, { color: colors.text }]} numberOfLines={1}>
+        <Text style={[styles.name, { color: colors.text, fontWeight: unreadCount && unreadCount > 0 ? '700' : '500' }]} numberOfLines={1}>
           {displayName}
         </Text>
         {messagePreview ? (
-          <Text style={[styles.preview, { color: colors.textMuted }]} numberOfLines={1}>
+          <Text style={[styles.preview, { color: unreadCount && unreadCount > 0 ? colors.textSecondary : colors.textMuted }]} numberOfLines={1}>
             {messagePreview}
           </Text>
         ) : null}

--- a/apps/mobile/src/components/conversation/conversation-screen.tsx
+++ b/apps/mobile/src/components/conversation/conversation-screen.tsx
@@ -1,7 +1,6 @@
 import { setStringAsync } from 'expo-clipboard';
 import { useEffect, useRef, useState } from 'react';
 import {
-  Alert,
   KeyboardAvoidingView,
   Platform,
   Pressable,
@@ -13,7 +12,8 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { LocalMessageNode, LocalNode } from '@colanode/client/types/nodes';
 import { EmojiPicker } from '@colanode/mobile/components/emojis/emoji-picker';
-import { LoadingScreen } from '@colanode/mobile/components/loading-screen';
+import { SkeletonMessageList } from '@colanode/mobile/components/ui/skeleton';
+import { useToast } from '@colanode/mobile/components/ui/toast';
 import { MessageActionSheet } from '@colanode/mobile/components/messages/message-action-sheet';
 import { EditTarget, MessageInput } from '@colanode/mobile/components/messages/message-input';
 import {
@@ -56,6 +56,7 @@ export const ConversationScreen = ({
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
   const [showRename, setShowRename] = useState(false);
   const { mutate } = useMutation();
+  const toast = useToast();
   const lastMarkedId = useRef<string | null>(null);
 
   useEffect(() => {
@@ -136,14 +137,14 @@ export const ConversationScreen = ({
         reaction: emoji,
       },
       onError(error) {
-        Alert.alert('Error', error.message);
+        toast.show(error.message);
       },
     });
     setActionTarget(null);
   };
 
   if (isLoading) {
-    return <LoadingScreen />;
+    return <SkeletonMessageList />;
   }
 
   return (

--- a/apps/mobile/src/components/emojis/emoji-picker.tsx
+++ b/apps/mobile/src/components/emojis/emoji-picker.tsx
@@ -14,6 +14,7 @@ import { BottomSheet } from '@colanode/mobile/components/ui/bottom-sheet';
 import { useTheme } from '@colanode/mobile/contexts/theme';
 import { useQuery } from '@colanode/mobile/hooks/use-query';
 import { codeToEmoji } from '@colanode/mobile/lib/emoji-utils';
+import { selectionChanged } from '@colanode/mobile/lib/haptics';
 
 const QUICK_REACTIONS = [
   { code: '1f44d', label: 'thumbs up' },
@@ -74,6 +75,7 @@ export const EmojiPicker = ({ visible, onClose, onSelect }: EmojiPickerProps) =>
 
   const handleSelect = useCallback(
     (unified: string) => {
+      selectionChanged();
       onSelect(codeToEmoji(unified));
       onClose();
       setSearchQuery('');
@@ -83,6 +85,7 @@ export const EmojiPicker = ({ visible, onClose, onSelect }: EmojiPickerProps) =>
 
   const handleQuickReact = useCallback(
     (code: string) => {
+      selectionChanged();
       onSelect(codeToEmoji(code));
       onClose();
     },

--- a/apps/mobile/src/components/messages/message-action-sheet.tsx
+++ b/apps/mobile/src/components/messages/message-action-sheet.tsx
@@ -1,4 +1,5 @@
 import Feather from '@expo/vector-icons/Feather';
+import { useEffect } from 'react';
 import {
   Alert,
   Pressable,
@@ -10,6 +11,7 @@ import { LocalMessageNode } from '@colanode/client/types/nodes';
 import { BottomSheet } from '@colanode/mobile/components/ui/bottom-sheet';
 import { useTheme } from '@colanode/mobile/contexts/theme';
 import { useMutation } from '@colanode/mobile/hooks/use-mutation';
+import { impactMedium } from '@colanode/mobile/lib/haptics';
 
 interface MessageActionSheetProps {
   visible: boolean;
@@ -39,6 +41,12 @@ export const MessageActionSheet = ({
 }: MessageActionSheetProps) => {
   const { mutate } = useMutation();
   const { colors } = useTheme();
+
+  useEffect(() => {
+    if (visible) {
+      impactMedium();
+    }
+  }, [visible]);
 
   const handleDelete = () => {
     if (!message) return;

--- a/apps/mobile/src/components/messages/message-input.tsx
+++ b/apps/mobile/src/components/messages/message-input.tsx
@@ -1,7 +1,6 @@
 import Feather from '@expo/vector-icons/Feather';
 import { useEffect, useState } from 'react';
 import {
-  Alert,
   Pressable,
   StyleSheet,
   Text,
@@ -18,8 +17,10 @@ import {
   IdType,
 } from '@colanode/core';
 import { ReplyTarget } from '@colanode/mobile/components/messages/message-item';
+import { useToast } from '@colanode/mobile/components/ui/toast';
 import { useTheme } from '@colanode/mobile/contexts/theme';
 import { useMutation } from '@colanode/mobile/hooks/use-mutation';
+import { impactLight, notificationSuccess } from '@colanode/mobile/lib/haptics';
 import { getMessageText } from '@colanode/mobile/lib/message-utils';
 
 export interface EditTarget {
@@ -67,6 +68,7 @@ export const MessageInput = ({
   const [text, setText] = useState('');
   const { mutate, isPending } = useMutation();
   const { colors } = useTheme();
+  const toast = useToast();
   const insets = useSafeAreaInsets();
 
   // When editTarget changes, pre-fill input
@@ -101,11 +103,12 @@ export const MessageInput = ({
           },
         },
         onSuccess() {
+          impactLight();
           setText('');
           onClearEdit?.();
         },
         onError(error) {
-          Alert.alert('Error', error.message);
+          toast.show(error.message);
         },
       });
       return;
@@ -136,11 +139,12 @@ export const MessageInput = ({
         referenceId: replyTo?.message.id,
       },
       onSuccess() {
+        notificationSuccess();
         setText('');
         onClearReply?.();
       },
       onError(error) {
-        Alert.alert('Error', error.message);
+        toast.show(error.message);
       },
     });
   };

--- a/apps/mobile/src/components/messages/message-list.tsx
+++ b/apps/mobile/src/components/messages/message-list.tsx
@@ -1,5 +1,15 @@
-import { useMemo } from 'react';
-import { FlatList, StyleSheet, Text, View } from 'react-native';
+import Feather from '@expo/vector-icons/Feather';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import {
+  Animated,
+  FlatList,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
 
 import { LocalMessageNode } from '@colanode/client/types/nodes';
 import { User } from '@colanode/client/types/users';
@@ -44,6 +54,8 @@ const buildGroups = (messages: LocalMessageNode[]): MessageGroup[] => {
   return groups.reverse();
 };
 
+const SCROLL_THRESHOLD = 300;
+
 export const MessageList = ({
   messages,
   users,
@@ -53,59 +65,106 @@ export const MessageList = ({
   const { colors } = useTheme();
   const groups = useMemo(() => buildGroups(messages), [messages]);
   const messageMap = useMemo(() => new Map(messages.map((m) => [m.id, m])), [messages]);
+  const flatListRef = useRef<FlatList>(null);
+  const [showScrollButton, setShowScrollButton] = useState(false);
+  const scrollButtonOpacity = useRef(new Animated.Value(0)).current;
+
+  const handleScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const offset = event.nativeEvent.contentOffset.y;
+      const shouldShow = offset > SCROLL_THRESHOLD;
+
+      if (shouldShow !== showScrollButton) {
+        setShowScrollButton(shouldShow);
+        Animated.timing(scrollButtonOpacity, {
+          toValue: shouldShow ? 1 : 0,
+          duration: 200,
+          useNativeDriver: true,
+        }).start();
+      }
+    },
+    [showScrollButton, scrollButtonOpacity]
+  );
+
+  const scrollToBottom = useCallback(() => {
+    flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
+  }, []);
 
   return (
-    <FlatList
-      data={groups}
-      keyExtractor={(item) => item.key}
-      inverted
-      renderItem={({ item }) => {
-        if (item.type === 'date') {
-          return (
-            <View style={styles.dateContainer}>
-              <Text style={[styles.dateText, { color: colors.textMuted }]}>{item.date}</Text>
-            </View>
-          );
+    <View style={styles.wrapper}>
+      <FlatList
+        ref={flatListRef}
+        data={groups}
+        keyExtractor={(item) => item.key}
+        inverted
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
+        removeClippedSubviews={true}
+        maxToRenderPerBatch={15}
+        windowSize={10}
+        renderItem={({ item }) => {
+          if (item.type === 'date') {
+            return (
+              <View style={styles.dateContainer}>
+                <Text style={[styles.dateText, { color: colors.textMuted }]}>{item.date}</Text>
+              </View>
+            );
+          }
+
+          if (item.message) {
+            const refId = item.message.referenceId;
+            const referencedMessage = refId ? messageMap.get(refId) : undefined;
+
+            return (
+              <MessageItem
+                message={item.message}
+                users={users}
+                isOwnMessage={item.message.createdBy === currentUserId}
+                onLongPress={onMessageAction}
+                referencedMessage={referencedMessage}
+                currentUserId={currentUserId}
+              />
+            );
+          }
+
+          return null;
+        }}
+        contentContainerStyle={[
+          styles.list,
+          groups.length === 0 && styles.emptyList,
+        ]}
+        ListEmptyComponent={
+          <View style={styles.emptyContainer}>
+            <Text style={[styles.emptyTitle, { color: colors.textMuted }]}>
+              No messages yet
+            </Text>
+            <Text style={[styles.emptySubtitle, { color: colors.textMuted }]}>
+              Start the conversation
+            </Text>
+          </View>
         }
-
-        if (item.message) {
-          const refId = item.message.referenceId;
-          const referencedMessage = refId ? messageMap.get(refId) : undefined;
-
-          return (
-            <MessageItem
-              message={item.message}
-              users={users}
-              isOwnMessage={item.message.createdBy === currentUserId}
-              onLongPress={onMessageAction}
-              referencedMessage={referencedMessage}
-              currentUserId={currentUserId}
-            />
-          );
-        }
-
-        return null;
-      }}
-      contentContainerStyle={[
-        styles.list,
-        groups.length === 0 && styles.emptyList,
-      ]}
-      ListEmptyComponent={
-        <View style={styles.emptyContainer}>
-          <Text style={[styles.emptyTitle, { color: colors.textMuted }]}>
-            No messages yet
-          </Text>
-          <Text style={[styles.emptySubtitle, { color: colors.textMuted }]}>
-            Start the conversation
-          </Text>
-        </View>
-      }
-      showsVerticalScrollIndicator={false}
-    />
+        showsVerticalScrollIndicator={false}
+      />
+      {showScrollButton && (
+        <Animated.View style={[styles.scrollButton, { opacity: scrollButtonOpacity }]}>
+          <Pressable
+            style={[styles.scrollButtonInner, { backgroundColor: colors.surface }]}
+            onPress={scrollToBottom}
+            accessibilityRole="button"
+            accessibilityLabel="Scroll to bottom"
+          >
+            <Feather name="chevron-down" size={20} color={colors.text} />
+          </Pressable>
+        </Animated.View>
+      )}
+    </View>
   );
 };
 
 const styles = StyleSheet.create({
+  wrapper: {
+    flex: 1,
+  },
   list: {
     paddingVertical: 8,
   },
@@ -132,5 +191,22 @@ const styles = StyleSheet.create({
   },
   emptySubtitle: {
     fontSize: 14,
+  },
+  scrollButton: {
+    position: 'absolute',
+    bottom: 16,
+    right: 16,
+  },
+  scrollButtonInner: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.2,
+    shadowRadius: 4,
+    elevation: 6,
   },
 });

--- a/apps/mobile/src/components/messages/message-reactions.tsx
+++ b/apps/mobile/src/components/messages/message-reactions.tsx
@@ -2,6 +2,7 @@ import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { NodeReaction } from '@colanode/client/types/nodes';
 import { useTheme } from '@colanode/mobile/contexts/theme';
+import { impactLight } from '@colanode/mobile/lib/haptics';
 
 interface MessageReactionsProps {
   reactions: NodeReaction[];
@@ -52,7 +53,10 @@ export const MessageReactions = ({
             { backgroundColor: colors.surfaceHover, borderColor: colors.border },
             g.hasOwnReaction && { borderColor: colors.primary, backgroundColor: colors.surfaceAccent },
           ]}
-          onPress={() => onToggleReaction(g.reaction)}
+          onPress={() => {
+            impactLight();
+            onToggleReaction(g.reaction);
+          }}
         >
           <Text style={styles.emoji}>{g.reaction}</Text>
           <Text

--- a/apps/mobile/src/components/nodes/create-node-sheet.tsx
+++ b/apps/mobile/src/components/nodes/create-node-sheet.tsx
@@ -1,7 +1,6 @@
 import Feather from '@expo/vector-icons/Feather';
 import { useState } from 'react';
 import {
-  Alert,
   Pressable,
   StyleSheet,
   Text,
@@ -11,6 +10,7 @@ import {
 
 import { generateId, IdType } from '@colanode/core';
 import { BottomSheet } from '@colanode/mobile/components/ui/bottom-sheet';
+import { useToast } from '@colanode/mobile/components/ui/toast';
 import { useTheme } from '@colanode/mobile/contexts/theme';
 import { useMutation } from '@colanode/mobile/hooks/use-mutation';
 
@@ -44,6 +44,7 @@ export const CreateNodeSheet = ({
   const [name, setName] = useState('');
   const { mutate, isPending } = useMutation();
   const { colors } = useTheme();
+  const toast = useToast();
 
   const handleCreate = () => {
     const trimmedName = name.trim();
@@ -68,7 +69,7 @@ export const CreateNodeSheet = ({
         onClose();
       },
       onError(error) {
-        Alert.alert('Error', error.message);
+        toast.show(error.message);
       },
     });
   };

--- a/apps/mobile/src/components/nodes/node-action-sheet.tsx
+++ b/apps/mobile/src/components/nodes/node-action-sheet.tsx
@@ -1,4 +1,5 @@
 import Feather from '@expo/vector-icons/Feather';
+import { useEffect } from 'react';
 import {
   Alert,
   Pressable,
@@ -9,6 +10,7 @@ import {
 import { BottomSheet } from '@colanode/mobile/components/ui/bottom-sheet';
 import { useTheme } from '@colanode/mobile/contexts/theme';
 import { useMutation } from '@colanode/mobile/hooks/use-mutation';
+import { impactMedium } from '@colanode/mobile/lib/haptics';
 
 interface NodeActionSheetProps {
   visible: boolean;
@@ -27,6 +29,12 @@ export const NodeActionSheet = ({
 }: NodeActionSheetProps) => {
   const { mutate } = useMutation();
   const { colors } = useTheme();
+
+  useEffect(() => {
+    if (visible) {
+      impactMedium();
+    }
+  }, [visible]);
 
   const handleDelete = () => {
     if (!nodeId) return;

--- a/apps/mobile/src/components/nodes/node-child-list.tsx
+++ b/apps/mobile/src/components/nodes/node-child-list.tsx
@@ -3,6 +3,7 @@ import { FlatList, Pressable, RefreshControl, StyleSheet, Text, View } from 'rea
 
 import { LocalNode } from '@colanode/client/types/nodes';
 import { NodeIcon } from '@colanode/mobile/components/nodes/node-icon';
+import { ListSeparator } from '@colanode/mobile/components/ui/list-separator';
 import { EmptyState } from '@colanode/mobile/components/ui/empty-state';
 import { SkeletonList } from '@colanode/mobile/components/ui/skeleton';
 import { useTheme } from '@colanode/mobile/contexts/theme';
@@ -59,9 +60,7 @@ export const NodeChildList = ({
           <Feather name="chevron-right" size={18} color={colors.sheetHandle} />
         </Pressable>
       )}
-      ItemSeparatorComponent={() => (
-        <View style={[styles.separator, { backgroundColor: colors.listSeparator }]} />
-      )}
+      ItemSeparatorComponent={() => <ListSeparator marginLeft={56} />}
       contentContainerStyle={styles.list}
       refreshControl={
         <RefreshControl
@@ -106,9 +105,5 @@ const styles = StyleSheet.create({
   },
   childType: {
     fontSize: 12,
-  },
-  separator: {
-    height: StyleSheet.hairlineWidth,
-    marginLeft: 56,
   },
 });

--- a/apps/mobile/src/components/nodes/rename-node-sheet.tsx
+++ b/apps/mobile/src/components/nodes/rename-node-sheet.tsx
@@ -1,7 +1,6 @@
 import Feather from '@expo/vector-icons/Feather';
 import { useEffect, useState } from 'react';
 import {
-  Alert,
   Dimensions,
   Pressable,
   StyleSheet,
@@ -16,6 +15,7 @@ import { NodeIcon } from '@colanode/mobile/components/nodes/node-icon';
 import { BottomSheet } from '@colanode/mobile/components/ui/bottom-sheet';
 import { Button } from '@colanode/mobile/components/ui/button';
 import { TextInput } from '@colanode/mobile/components/ui/text-input';
+import { useToast } from '@colanode/mobile/components/ui/toast';
 import { useTheme } from '@colanode/mobile/contexts/theme';
 import { useMutation } from '@colanode/mobile/hooks/use-mutation';
 
@@ -96,6 +96,7 @@ export const RenameNodeSheet = ({
   const [showAvatarPicker, setShowAvatarPicker] = useState(false);
   const { mutate, isPending } = useMutation();
   const { colors } = useTheme();
+  const toast = useToast();
 
   useEffect(() => {
     if (visible && node && (node.type === 'space' || node.type === 'channel' || node.type === 'page' || node.type === 'folder')) {
@@ -121,7 +122,7 @@ export const RenameNodeSheet = ({
         onRenamed?.();
       },
       onError(error) {
-        Alert.alert('Error', error.message);
+        toast.show(error.message);
       },
     });
   };

--- a/apps/mobile/src/components/spaces/space-add-collaborator-sheet.tsx
+++ b/apps/mobile/src/components/spaces/space-add-collaborator-sheet.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import {
-  Alert,
   FlatList,
   Pressable,
   StyleSheet,
@@ -12,6 +11,7 @@ import { NodeRole } from '@colanode/core';
 import { UserAvatar } from '@colanode/mobile/components/avatars/avatar';
 import { BottomSheet } from '@colanode/mobile/components/ui/bottom-sheet';
 import { TextInput } from '@colanode/mobile/components/ui/text-input';
+import { useToast } from '@colanode/mobile/components/ui/toast';
 import { useTheme } from '@colanode/mobile/contexts/theme';
 import { useMutation } from '@colanode/mobile/hooks/use-mutation';
 import { useQuery } from '@colanode/mobile/hooks/use-query';
@@ -40,6 +40,7 @@ export const SpaceAddCollaboratorSheet = ({
 }: SpaceAddCollaboratorSheetProps) => {
   const { colors } = useTheme();
   const { mutate, isPending } = useMutation();
+  const toast = useToast();
   const [search, setSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const [role, setRole] = useState<NodeRole>('editor');
@@ -89,7 +90,7 @@ export const SpaceAddCollaboratorSheet = ({
         onClose();
       },
       onError(error) {
-        Alert.alert('Error', error.message);
+        toast.show(error.message);
       },
     });
   };

--- a/apps/mobile/src/components/spaces/space-collaborator-role-sheet.tsx
+++ b/apps/mobile/src/components/spaces/space-collaborator-role-sheet.tsx
@@ -11,6 +11,7 @@ import {
 
 import { NodeRole } from '@colanode/core';
 import { BottomSheet } from '@colanode/mobile/components/ui/bottom-sheet';
+import { useToast } from '@colanode/mobile/components/ui/toast';
 import { useTheme } from '@colanode/mobile/contexts/theme';
 import { useMutation } from '@colanode/mobile/hooks/use-mutation';
 
@@ -54,6 +55,7 @@ export const SpaceCollaboratorRoleSheet = ({
 }: SpaceCollaboratorRoleSheetProps) => {
   const { colors } = useTheme();
   const { mutate, isPending } = useMutation();
+  const toast = useToast();
 
   const handleRoleChange = (role: NodeRole) => {
     if (!collaborator || isPending || !canEdit) return;
@@ -74,7 +76,7 @@ export const SpaceCollaboratorRoleSheet = ({
         onClose();
       },
       onError(error) {
-        Alert.alert('Error', error.message);
+        toast.show(error.message);
       },
     });
   };
@@ -102,7 +104,7 @@ export const SpaceCollaboratorRoleSheet = ({
                 onClose();
               },
               onError(error) {
-                Alert.alert('Error', error.message);
+                toast.show(error.message);
               },
             });
           },

--- a/apps/mobile/src/components/ui/list-separator.tsx
+++ b/apps/mobile/src/components/ui/list-separator.tsx
@@ -1,0 +1,26 @@
+import { StyleSheet, View } from 'react-native';
+
+import { useTheme } from '@colanode/mobile/contexts/theme';
+
+interface ListSeparatorProps {
+  marginLeft?: number;
+}
+
+export const ListSeparator = ({ marginLeft = 0 }: ListSeparatorProps) => {
+  const { colors } = useTheme();
+
+  return (
+    <View
+      style={[
+        styles.separator,
+        { backgroundColor: colors.listSeparator, marginLeft },
+      ]}
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  separator: {
+    height: StyleSheet.hairlineWidth,
+  },
+});

--- a/apps/mobile/src/components/ui/skeleton.tsx
+++ b/apps/mobile/src/components/ui/skeleton.tsx
@@ -89,6 +89,33 @@ export const SkeletonMessageList = ({ count = 4 }: SkeletonListProps) => {
   );
 };
 
+export const SkeletonPage = () => {
+  return (
+    <View style={styles.page}>
+      <Skeleton width="50%" height={22} borderRadius={6} />
+      <View style={styles.pageLines}>
+        <Skeleton width="90%" height={14} />
+        <Skeleton width="75%" height={14} />
+        <Skeleton width="85%" height={14} />
+        <Skeleton width="60%" height={14} />
+        <Skeleton width="70%" height={14} />
+      </View>
+    </View>
+  );
+};
+
+export const SkeletonFilePreview = () => {
+  return (
+    <View style={styles.filePreview}>
+      <Skeleton width="100%" height={200} borderRadius={12} />
+      <View style={styles.fileMeta}>
+        <Skeleton width="60%" height={14} />
+        <Skeleton width="40%" height={12} />
+      </View>
+    </View>
+  );
+};
+
 const styles = StyleSheet.create({
   row: {
     flexDirection: 'row',
@@ -124,5 +151,19 @@ const styles = StyleSheet.create({
     gap: 6,
     maxWidth: '70%',
     padding: 12,
+  },
+  page: {
+    padding: 16,
+    gap: 20,
+  },
+  pageLines: {
+    gap: 10,
+  },
+  filePreview: {
+    padding: 16,
+    gap: 16,
+  },
+  fileMeta: {
+    gap: 8,
   },
 });

--- a/apps/mobile/src/components/ui/toast.tsx
+++ b/apps/mobile/src/components/ui/toast.tsx
@@ -1,0 +1,153 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import {
+  Animated,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { useTheme } from '@colanode/mobile/contexts/theme';
+
+type ToastVariant = 'success' | 'error' | 'info';
+
+interface ToastMessage {
+  id: number;
+  text: string;
+  variant: ToastVariant;
+}
+
+interface ToastContextValue {
+  show: (text: string, variant?: ToastVariant) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+export const useToast = (): ToastContextValue => {
+  const ctx = useContext(ToastContext);
+  if (!ctx) {
+    throw new Error('useToast must be used within ToastProvider');
+  }
+  return ctx;
+};
+
+interface ToastProviderProps {
+  children: React.ReactNode;
+}
+
+export const ToastProvider = ({ children }: ToastProviderProps) => {
+  const [toast, setToast] = useState<ToastMessage | null>(null);
+  const nextId = useRef(0);
+
+  const show = useCallback((text: string, variant: ToastVariant = 'error') => {
+    const id = ++nextId.current;
+    setToast({ id, text, variant });
+  }, []);
+
+  const dismiss = useCallback(() => {
+    setToast(null);
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ show }}>
+      {children}
+      {toast && (
+        <ToastBanner
+          key={toast.id}
+          text={toast.text}
+          variant={toast.variant}
+          onDismiss={dismiss}
+        />
+      )}
+    </ToastContext.Provider>
+  );
+};
+
+interface ToastBannerProps {
+  text: string;
+  variant: ToastVariant;
+  onDismiss: () => void;
+}
+
+const ToastBanner = ({ text, variant, onDismiss }: ToastBannerProps) => {
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const translateY = useRef(new Animated.Value(-100)).current;
+
+  useEffect(() => {
+    Animated.spring(translateY, {
+      toValue: 0,
+      useNativeDriver: true,
+      tension: 80,
+      friction: 12,
+    }).start();
+
+    const timer = setTimeout(() => {
+      Animated.timing(translateY, {
+        toValue: -100,
+        duration: 200,
+        useNativeDriver: true,
+      }).start(() => onDismiss());
+    }, 3000);
+
+    return () => clearTimeout(timer);
+  }, [translateY, onDismiss]);
+
+  const backgroundColor =
+    variant === 'error'
+      ? colors.error
+      : variant === 'success'
+        ? colors.success
+        : colors.primary;
+
+  return (
+    <Animated.View
+      style={[
+        styles.container,
+        { top: insets.top + 8, transform: [{ translateY }] },
+      ]}
+    >
+      <Pressable
+        style={[styles.banner, { backgroundColor }]}
+        onPress={onDismiss}
+      >
+        <Text style={styles.text} numberOfLines={2}>
+          {text}
+        </Text>
+      </Pressable>
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    left: 16,
+    right: 16,
+    zIndex: 9999,
+  },
+  banner: {
+    borderRadius: 10,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 6,
+  },
+  text: {
+    color: '#ffffff',
+    fontSize: 14,
+    fontWeight: '500',
+    textAlign: 'center',
+  },
+});

--- a/apps/mobile/src/hooks/use-folder-file-upload.ts
+++ b/apps/mobile/src/hooks/use-folder-file-upload.ts
@@ -1,8 +1,8 @@
 import * as DocumentPicker from 'expo-document-picker';
 import { useRef } from 'react';
-import { Alert } from 'react-native';
 
 import { extractFileSubtype, generateId, IdType } from '@colanode/core';
+import { useToast } from '@colanode/mobile/components/ui/toast';
 import { useAppService } from '@colanode/mobile/contexts/app-service';
 import { useMutation } from '@colanode/mobile/hooks/use-mutation';
 
@@ -14,6 +14,7 @@ interface UseFolderFileUploadOptions {
 export const useFolderFileUpload = ({ parentId, userId }: UseFolderFileUploadOptions) => {
   const { appService } = useAppService();
   const { mutate } = useMutation();
+  const toast = useToast();
   const pickingRef = useRef(false);
 
   const pickAndUploadFile = async () => {
@@ -58,17 +59,17 @@ export const useFolderFileUpload = ({ parentId, userId }: UseFolderFileUploadOpt
               tempFileId: tempId,
             },
             onError(error) {
-              Alert.alert('Error', error.message);
+              toast.show(error.message);
             },
           });
         },
         onError(error) {
-          Alert.alert('Error', error.message);
+          toast.show(error.message);
         },
       });
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : 'Failed to pick file';
-      Alert.alert('Error', message);
+      toast.show(message);
     } finally {
       pickingRef.current = false;
     }

--- a/apps/mobile/src/lib/haptics.ts
+++ b/apps/mobile/src/lib/haptics.ts
@@ -1,0 +1,41 @@
+import * as Haptics from 'expo-haptics';
+
+export const impactLight = () => {
+  try {
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+  } catch {
+    // Haptics not available (e.g. simulator)
+  }
+};
+
+export const impactMedium = () => {
+  try {
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+  } catch {
+    // Haptics not available
+  }
+};
+
+export const selectionChanged = () => {
+  try {
+    void Haptics.selectionAsync();
+  } catch {
+    // Haptics not available
+  }
+};
+
+export const notificationSuccess = () => {
+  try {
+    void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+  } catch {
+    // Haptics not available
+  }
+};
+
+export const notificationError = () => {
+  try {
+    void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+  } catch {
+    // Haptics not available
+  }
+};

--- a/apps/mobile/src/services/kysely-service.ts
+++ b/apps/mobile/src/services/kysely-service.ts
@@ -149,7 +149,11 @@ class ExpoSqliteConnection implements DatabaseConnection {
         numChangedRows: BigInt(result.changes),
       };
     } catch (error) {
-      console.error('SQLite query failed:', sql, parameters, error);
+      if (__DEV__) {
+        console.error('SQLite query failed:', sql, parameters, error);
+      } else {
+        console.error('SQLite query failed:', error);
+      }
       throw error;
     } finally {
       await statement?.finalizeAsync();

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,7 @@
         "expo-device": "~8.0.10",
         "expo-document-picker": "^55.0.8",
         "expo-file-system": "~19.0.21",
+        "expo-haptics": "~15.0.8",
         "expo-image-picker": "~17.0.10",
         "expo-linking": "~8.0.11",
         "expo-router": "~6.0.23",
@@ -20176,6 +20177,15 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-haptics": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-haptics/-/expo-haptics-15.0.8.tgz",
+      "integrity": "sha512-lftutojy8Qs8zaDzzjwM3gKHFZ8bOOEZDCkmh2Ddpe95Ra6kt2izeOfOfKuP/QEh0MZ1j9TfqippyHdRd1ZM9g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-image-loader": {


### PR DESCRIPTION
## Summary
- Replace blocking `Alert.alert` error callbacks with non-blocking slide-down toast notifications (new `ToastProvider` + `useToast` hook) across ~15 mutation error handlers, keeping destructive confirmations as alerts
- Add `expo-haptics` for tactile feedback on long-press actions, message send/edit, emoji selection, and reaction toggles
- Sort chat lists by `updatedAt` instead of `createdAt` so most-recently-active conversations appear first; bold unread chat names with higher-contrast preview text
- Add contextual skeleton loading placeholders (page, file, message list, item list variants) replacing generic `ActivityIndicator` spinners
- Add animated scroll-to-bottom floating button in message lists, extract reusable `ListSeparator` component, gate SQL query logging behind `__DEV__`, and tune FlatList performance

## Test plan
- [ ] Trigger a mutation error (e.g. send message offline) — should show slide-down toast, not blocking alert
- [ ] Long-press a message — haptic feedback on device (simulator won't vibrate)
- [ ] Send a message in an older chat — chat should jump to top of list
- [ ] Receive a message — chat name should appear bold in list
- [ ] Navigate to spaces/chats while loading — should see skeleton shimmer placeholders
- [ ] Scroll up in a conversation — floating scroll-to-bottom button appears; tap to scroll back

🤖 Generated with [Claude Code](https://claude.com/claude-code)