### PR TITLE
Mobilie: Fix workspace lifecycle: sync init, cleanup, and auth selection

### DIFF
--- a/packages/client/src/handlers/mutations/auth/base.ts
+++ b/packages/client/src/handlers/mutations/auth/base.ts
@@ -1,5 +1,9 @@
 import { eventBus } from '@colanode/client/lib/event-bus';
-import { mapAccount, mapWorkspace } from '@colanode/client/lib/mappers';
+import {
+  mapAccount,
+  mapMetadata,
+  mapWorkspace,
+} from '@colanode/client/lib/mappers';
 import { MutationError, MutationErrorCode } from '@colanode/client/mutations';
 import { AppService } from '@colanode/client/services/app-service';
 import { ServerService } from '@colanode/client/services/server-service';
@@ -105,6 +109,33 @@ export abstract class AuthMutationHandlerBase {
         type: 'workspace.created',
         workspace: mapWorkspace(createdWorkspace),
       });
+    }
+
+    if (createdWorkspaces.length > 0) {
+      const firstWorkspace = createdWorkspaces[0]!;
+      const updatedMetadata = await this.app.database
+        .insertInto('metadata')
+        .returningAll()
+        .values({
+          namespace: 'app',
+          key: 'workspace',
+          value: JSON.stringify(firstWorkspace.user_id),
+          created_at: new Date().toISOString(),
+        })
+        .onConflict((cb) =>
+          cb.columns(['namespace', 'key']).doUpdateSet({
+            value: JSON.stringify(firstWorkspace.user_id),
+            updated_at: new Date().toISOString(),
+          })
+        )
+        .executeTakeFirst();
+
+      if (updatedMetadata) {
+        eventBus.publish({
+          type: 'metadata.updated',
+          metadata: mapMetadata(updatedMetadata),
+        });
+      }
     }
   }
 }

--- a/packages/client/src/services/app-service.ts
+++ b/packages/client/src/services/app-service.ts
@@ -82,11 +82,33 @@ export class AppService {
 
     this.metadata = new MetadataService(this);
 
-    this.eventSubscriptionId = eventBus.subscribe((event) => {
+    this.eventSubscriptionId = eventBus.subscribe(async (event) => {
       if (event.type === 'account.deleted') {
         this.accounts.delete(event.account.id);
       } else if (event.type === 'workspace.deleted') {
-        this.workspaces.delete(event.workspace.userId);
+        const workspace = this.workspaces.get(event.workspace.userId);
+        if (workspace) {
+          this.workspaces.delete(event.workspace.userId);
+          await workspace.cleanup();
+        }
+      } else if (event.type === 'workspace.created') {
+        if (this.workspaces.has(event.workspace.userId)) {
+          return;
+        }
+
+        const workspaceRow = await this.database
+          .selectFrom('workspaces')
+          .selectAll()
+          .where('user_id', '=', event.workspace.userId)
+          .executeTakeFirst();
+
+        if (workspaceRow) {
+          try {
+            await this.initWorkspace(workspaceRow);
+          } catch (error) {
+            debug(`Failed to init synced workspace: ${error}`);
+          }
+        }
       }
     });
   }

--- a/packages/client/src/services/workspaces/workspace-service.ts
+++ b/packages/client/src/services/workspaces/workspace-service.ts
@@ -139,7 +139,7 @@ export class WorkspaceService {
     await migrator.migrateToLatest();
   }
 
-  public async delete(): Promise<void> {
+  public async cleanup(): Promise<void> {
     try {
       // Stop services first so they don't trigger new DB queries
       this.synchronizer.destroy();
@@ -161,11 +161,6 @@ export class WorkspaceService {
 
       await this.account.app.fs.delete(workspacePath);
 
-      await this.account.app.database
-        .deleteFrom('workspaces')
-        .where('user_id', '=', this.workspace.userId)
-        .execute();
-
       const deletedMetadata = await this.account.app.database
         .deleteFrom('metadata')
         .returningAll()
@@ -184,6 +179,21 @@ export class WorkspaceService {
       await this.account.app.jobs.removeJobSchedule(
         this.workspaceFilesCleanJobScheduleId
       );
+    } catch (error) {
+      debug(
+        `Error cleaning up workspace ${this.workspace.workspaceId}: ${error}`
+      );
+    }
+  }
+
+  public async delete(): Promise<void> {
+    try {
+      await this.cleanup();
+
+      await this.account.app.database
+        .deleteFrom('workspaces')
+        .where('user_id', '=', this.workspace.userId)
+        .execute();
 
       eventBus.publish({
         type: 'workspace.deleted',


### PR DESCRIPTION
## Summary

- **Auto-initialize synced workspaces**: When `AccountService.sync()` discovers a new workspace (e.g., user invited), AppService now handles the `workspace.created` event to initialize the `WorkspaceService`, making the workspace usable without app restart.
- **Clean up deleted workspaces properly**: Extracted `cleanup()` from `WorkspaceService.delete()` so sync-triggered deletions tear down runtime state (stop synchronizers, close DB, delete files) instead of just removing the in-memory reference.
- **Select workspace on auth success**: After login/register, the newly created workspace is persisted as the active workspace via metadata upsert, preventing multi-account scenarios from landing in the wrong workspace.

## Test plan

- [ ] Log into account A, then log into account B — verify landing in account B's workspace
- [ ] Invite a user to a workspace from another client — verify the workspace appears and is usable without restart
- [ ] Remove a user from a workspace server-side — verify the workspace disappears and files are cleaned up
- [ ] Verify normal logout still works correctly (delete → cleanup → DB record removal → event)

🤖 Generated with [Claude Code](https://claude.com/claude-code)