### PR TITLE
Mobile: stability fixes for auth, editor sync, and file downloads

### DIFF
--- a/apps/mobile/app/(app)/(settings)/members.tsx
+++ b/apps/mobile/app/(app)/(settings)/members.tsx
@@ -97,6 +97,11 @@ export default function MembersScreen() {
       return;
     }
 
+    // Non-owners cannot modify owner roles
+    if (member.role === 'owner' && role !== 'owner') {
+      return;
+    }
+
     setSelectedUser(member);
     setPendingRole(null);
   };
@@ -287,7 +292,10 @@ export default function MembersScreen() {
               style={styles.sheetList}
               contentContainerStyle={styles.sheetListContent}
             >
-              {ROLE_OPTIONS.map((roleOption) => {
+              {ROLE_OPTIONS.filter(
+                (roleOption) =>
+                  roleOption.value !== 'owner' || role === 'owner'
+              ).map((roleOption) => {
                 const isSelected = selectedUser.role === roleOption.value;
                 const isUpdatingRole =
                   isPending && pendingRole === roleOption.value;

--- a/apps/mobile/app/(app)/(settings)/workspace.tsx
+++ b/apps/mobile/app/(app)/(settings)/workspace.tsx
@@ -34,7 +34,7 @@ export default function WorkspaceSettingsScreen() {
   );
   const [error, setError] = useState('');
 
-  const canEdit = role === 'owner' || role === 'admin';
+  const canEdit = role === 'owner';
 
   useEffect(() => {
     setName(workspace.name);
@@ -94,8 +94,8 @@ export default function WorkspaceSettingsScreen() {
                   input: {
                     type: 'workspace.update',
                     userId,
-                    name: workspace.name,
-                    description: workspace.description ?? '',
+                    name: name.trim() || workspace.name,
+                    description: description.trim(),
                     avatar: avatarId,
                   },
                 });

--- a/apps/mobile/app/(app)/(spaces)/file/[fileId].tsx
+++ b/apps/mobile/app/(app)/(spaces)/file/[fileId].tsx
@@ -15,12 +15,14 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { DownloadStatus } from '@colanode/client/types/files';
 import { LocalFileNode } from '@colanode/client/types/nodes';
 import { SkeletonFilePreview } from '@colanode/mobile/components/ui/skeleton';
 import { BackButton } from '@colanode/mobile/components/ui/back-button';
 import { useAppService } from '@colanode/mobile/contexts/app-service';
 import { useTheme } from '@colanode/mobile/contexts/theme';
 import { useWorkspace } from '@colanode/mobile/contexts/workspace';
+import { useLiveQuery } from '@colanode/mobile/hooks/use-live-query';
 import { useMutation } from '@colanode/mobile/hooks/use-mutation';
 import { useNodeQuery } from '@colanode/mobile/hooks/use-node-query';
 import { formatFileSize } from '@colanode/mobile/lib/format-utils';
@@ -42,10 +44,18 @@ export default function FileScreen() {
   const { mutate, isPending } = useMutation();
   const [fileUri, setFileUri] = useState<string | null>(null);
   const [downloading, setDownloading] = useState(false);
+  const downloadingRef = useRef(false);
   const isMountedRef = useRef(true);
   const downloadTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const { data: file, isLoading } = useNodeQuery<LocalFileNode>(userId, fileId, 'file');
+
+  // Reactively track download status via local.file.get
+  const { data: localFile } = useLiveQuery({
+    type: 'local.file.get',
+    fileId: fileId!,
+    userId,
+  });
 
   useEffect(() => {
     return () => {
@@ -56,36 +66,67 @@ export default function FileScreen() {
     };
   }, []);
 
+  // Update fileUri reactively when download completes
   useEffect(() => {
-    let cancelled = false;
-
     if (!file) {
       setFileUri(null);
+      return;
+    }
+
+    if (localFile?.downloadStatus === DownloadStatus.Completed) {
+      const path = appService.path.workspaceFile(userId, file.id, file.extension);
+      let cancelled = false;
+      appService.fs.exists(path).then((exists: boolean) => {
+        if (!cancelled && isMountedRef.current) {
+          setFileUri(exists ? path : null);
+          setDownloading(false);
+          downloadingRef.current = false;
+          if (downloadTimerRef.current) {
+            clearTimeout(downloadTimerRef.current);
+            downloadTimerRef.current = null;
+          }
+        }
+      });
       return () => {
         cancelled = true;
       };
     }
 
-    const path = appService.path.workspaceFile(userId, file.id, file.extension);
-    appService.fs.exists(path).then((exists: boolean) => {
-      if (!cancelled && isMountedRef.current) {
-        setFileUri(exists ? path : null);
+    if (localFile?.downloadStatus === DownloadStatus.Failed) {
+      setDownloading(false);
+      downloadingRef.current = false;
+      if (downloadTimerRef.current) {
+        clearTimeout(downloadTimerRef.current);
+        downloadTimerRef.current = null;
       }
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [file, userId, appService]);
+      Alert.alert(
+        'Download Failed',
+        localFile.downloadErrorMessage ?? 'An error occurred while downloading the file.'
+      );
+      return;
+    }
+
+    // No local file record yet — check filesystem directly
+    if (!localFile) {
+      const path = appService.path.workspaceFile(userId, file.id, file.extension);
+      let cancelled = false;
+      appService.fs.exists(path).then((exists: boolean) => {
+        if (!cancelled && isMountedRef.current) {
+          setFileUri(exists ? path : null);
+        }
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
+  }, [file, localFile, userId, appService]);
 
   const handleDownload = () => {
     if (!file || downloading || isPending) return;
 
     const path = appService.path.workspaceFile(userId, file.id, file.extension);
     setDownloading(true);
-    if (downloadTimerRef.current) {
-      clearTimeout(downloadTimerRef.current);
-      downloadTimerRef.current = null;
-    }
+    downloadingRef.current = true;
 
     mutate({
       input: {
@@ -94,48 +135,25 @@ export default function FileScreen() {
         fileId: file.id,
         path,
       },
-      async onSuccess() {
-        let attempts = 0;
-
-        const check = async () => {
-          if (!isMountedRef.current) {
-            return;
-          }
-
-          const exists = await appService.fs.exists(path);
-
-          if (!isMountedRef.current) {
-            return;
-          }
-
-          if (exists) {
-            setFileUri(path);
+      onSuccess() {
+        // Download initiated — useLiveQuery on local.file.get will
+        // reactively update when download_status changes.
+        // Set a fallback timeout in case events are missed.
+        downloadTimerRef.current = setTimeout(() => {
+          if (isMountedRef.current && downloadingRef.current) {
             setDownloading(false);
-            downloadTimerRef.current = null;
-            return;
+            downloadingRef.current = false;
+            Alert.alert(
+              'Download Timeout',
+              'The download is taking longer than expected. Please try again.'
+            );
           }
-
-          if (attempts < 30) {
-            attempts++;
-            downloadTimerRef.current = setTimeout(() => {
-              void check();
-            }, 1000);
-          } else {
-            setDownloading(false);
-            downloadTimerRef.current = null;
-          }
-        };
-
-        await check();
+        }, 60000);
       },
       onError() {
-        if (downloadTimerRef.current) {
-          clearTimeout(downloadTimerRef.current);
-          downloadTimerRef.current = null;
-        }
-
         if (isMountedRef.current) {
           setDownloading(false);
+          downloadingRef.current = false;
         }
       },
     });

--- a/apps/mobile/src/components/auth/email-register-form.tsx
+++ b/apps/mobile/src/components/auth/email-register-form.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 
+import { newPasswordSchema } from '@colanode/core';
 import { Button } from '@colanode/mobile/components/ui/button';
 import { TextInput } from '@colanode/mobile/components/ui/text-input';
 
@@ -37,16 +38,10 @@ export const EmailRegisterForm = ({
       newErrors.email = 'Invalid email address';
     }
 
-    if (!password) {
-      newErrors.password = 'Password is required';
-    } else if (password.length < 8) {
-      newErrors.password = 'Password must be at least 8 characters';
-    } else if (!/[A-Z]/.test(password)) {
-      newErrors.password = 'Must contain an uppercase letter';
-    } else if (!/[a-z]/.test(password)) {
-      newErrors.password = 'Must contain a lowercase letter';
-    } else if (!/[^A-Za-z0-9]/.test(password)) {
-      newErrors.password = 'Must contain a special character';
+    const passwordResult = newPasswordSchema.safeParse(password);
+    if (!passwordResult.success) {
+      newErrors.password =
+        passwordResult.error.issues[0]?.message ?? 'Invalid password';
     }
 
     if (confirmPassword !== password) {

--- a/apps/mobile/src/components/auth/password-reset-complete-form.tsx
+++ b/apps/mobile/src/components/auth/password-reset-complete-form.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
+import { newPasswordSchema } from '@colanode/core';
 import { Button } from '@colanode/mobile/components/ui/button';
 import { TextInput } from '@colanode/mobile/components/ui/text-input';
 import { useTheme } from '@colanode/mobile/contexts/theme';
@@ -48,16 +49,10 @@ export const PasswordResetCompleteForm = ({
       newErrors.otp = 'Verification code is required';
     }
 
-    if (!password) {
-      newErrors.password = 'Password is required';
-    } else if (password.length < 8) {
-      newErrors.password = 'Password must be at least 8 characters';
-    } else if (!/[A-Z]/.test(password)) {
-      newErrors.password = 'Must contain an uppercase letter';
-    } else if (!/[a-z]/.test(password)) {
-      newErrors.password = 'Must contain a lowercase letter';
-    } else if (!/[^A-Za-z0-9]/.test(password)) {
-      newErrors.password = 'Must contain a special character';
+    const passwordResult = newPasswordSchema.safeParse(password);
+    if (!passwordResult.success) {
+      newErrors.password =
+        passwordResult.error.issues[0]?.message ?? 'Invalid password';
     }
 
     if (confirmPassword !== password) {

--- a/apps/mobile/src/components/pages/page-webview.tsx
+++ b/apps/mobile/src/components/pages/page-webview.tsx
@@ -67,6 +67,7 @@ export const PageWebView = forwardRef<PageWebViewHandle, PageWebViewProps>(
   const webViewRef = useRef<WebView>(null);
   const isReadyRef = useRef(false);
   const revisionRef = useRef(state?.revision ?? '0');
+  const sentUpdateIdsRef = useRef<Set<string>>(new Set());
   const [editorHtml, setEditorHtml] = useState<string | null>(null);
   const [webViewReady, setWebViewReady] = useState(false);
 
@@ -115,6 +116,8 @@ export const PageWebView = forwardRef<PageWebViewHandle, PageWebViewProps>(
         title,
       },
     });
+    // Track which updates have been sent to avoid re-sending
+    sentUpdateIdsRef.current = new Set(updates.map((u) => u.id));
   }, [
     nodeId,
     userId,
@@ -129,18 +132,26 @@ export const PageWebView = forwardRef<PageWebViewHandle, PageWebViewProps>(
     sendMessage,
   ]);
 
-  // Send state updates when revision changes
+  // Send state updates when revision changes or new updates arrive
   useEffect(() => {
     if (!isReadyRef.current) return;
     if (!state) return;
-    if (revisionRef.current === state.revision) return;
+
+    const newUpdates = updates.filter((u) => !sentUpdateIdsRef.current.has(u.id));
+    const revisionChanged = revisionRef.current !== state.revision;
+
+    if (!revisionChanged && newUpdates.length === 0) return;
 
     revisionRef.current = state.revision;
+    for (const u of newUpdates) {
+      sentUpdateIdsRef.current.add(u.id);
+    }
+
     sendMessage({
       type: 'state.update',
       payload: {
         state: state.state,
-        updates: updates.map((u) => u.data),
+        updates: newUpdates.map((u) => u.data),
         revision: state.revision,
       },
     });

--- a/apps/mobile/src/services/file-system.ts
+++ b/apps/mobile/src/services/file-system.ts
@@ -132,11 +132,11 @@ export class MobileFileSystem implements FileSystem {
     await file.delete();
   }
 
-  public async url(path: string): Promise<string> {
+  public async url(path: string): Promise<string | null> {
     const file = new ExpoFile(path);
 
     if (!file.exists) {
-      throw new Error(`File not found: ${path}`);
+      return null;
     }
 
     return file.uri;

--- a/apps/mobile/webviews/editor/src/document-editor.tsx
+++ b/apps/mobile/webviews/editor/src/document-editor.tsx
@@ -114,6 +114,45 @@ export const DocumentEditor = ({
   const hasPendingChanges = useRef(false);
   const revisionRef = useRef(state?.revision ?? 0);
   const ydocRef = useRef<YDoc>(buildYDoc(state, updates));
+  const pendingRemoteRef = useRef<{
+    state: DocumentState;
+    updates: DocumentUpdate[];
+  } | null>(null);
+  const editorRef = useRef<ReturnType<typeof useEditor>>(null);
+  const appliedUpdateIdsRef = useRef<Set<string>>(
+    new Set(updates.map((u) => u.id))
+  );
+
+  const reconcileRef = useRef(
+    (
+      ed: NonNullable<ReturnType<typeof useEditor>>,
+      remoteState: DocumentState,
+      remoteUpdates: DocumentUpdate[],
+      nodeId: string
+    ) => {
+      const beforeContent = ydocRef.current.getObject<RichTextContent>();
+
+      ydocRef.current.applyUpdate(remoteState.state);
+      for (const update of remoteUpdates) {
+        ydocRef.current.applyUpdate(update.data);
+      }
+
+      const afterContent = ydocRef.current.getObject<RichTextContent>();
+
+      revisionRef.current = remoteState.revision;
+
+      if (isEqual(afterContent, beforeContent)) return;
+
+      const editorContent = buildEditorContent(nodeId, afterContent);
+
+      const relativeSelection = getRelativeSelection(ed);
+      ed.chain().setContent(editorContent).run();
+
+      if (relativeSelection != null) {
+        restoreRelativeSelection(ed, relativeSelection);
+      }
+    }
+  );
 
   const debouncedSave = useMemo(
     () =>
@@ -157,10 +196,26 @@ export const DocumentEditor = ({
           });
         } finally {
           hasPendingChanges.current = false;
+
+          // Replay stashed remote updates that arrived during local editing
+          const stashed = pendingRemoteRef.current;
+          if (stashed && editorRef.current) {
+            pendingRemoteRef.current = null;
+            for (const u of stashed.updates) {
+              appliedUpdateIdsRef.current.add(u.id);
+            }
+            reconcileRef.current(
+              editorRef.current,
+              stashed.state,
+              stashed.updates,
+              node.id
+            );
+          }
         }
       }, 500),
     [node.id, workspace.userId]
   );
+
 
   const editor = useEditor(
     {
@@ -266,39 +321,32 @@ export const DocumentEditor = ({
     [node.id]
   );
 
+  // Keep editorRef in sync for use in debouncedSave replay
+  editorRef.current = editor;
+
   // Reconciliation: apply remote state updates to editor
   // Uses a ref to track whether we have local pending changes
   useEffect(() => {
     if (!editor) return;
     if (!state) return;
 
-    // Always skip reconciliation if we have pending local changes
-    if (hasPendingChanges.current) return;
+    const revisionChanged = revisionRef.current !== state.revision;
+    const hasNewUpdates = updates.some(
+      (u) => !appliedUpdateIdsRef.current.has(u.id)
+    );
 
-    if (revisionRef.current === state?.revision) return;
+    if (!revisionChanged && !hasNewUpdates) return;
 
-    const beforeContent = ydocRef.current.getObject<RichTextContent>();
-
-    ydocRef.current.applyUpdate(state.state);
-    for (const update of updates) {
-      ydocRef.current.applyUpdate(update.data);
+    // Stash remote updates when local edits are pending — replayed after save
+    if (hasPendingChanges.current) {
+      pendingRemoteRef.current = { state, updates };
+      return;
     }
 
-    const afterContent = ydocRef.current.getObject<RichTextContent>();
-
-    // Update revision even if content is equal
-    revisionRef.current = state.revision;
-
-    if (isEqual(afterContent, beforeContent)) return;
-
-    const editorContent = buildEditorContent(node.id, afterContent);
-
-    const relativeSelection = getRelativeSelection(editor);
-    editor.chain().setContent(editorContent).run();
-
-    if (relativeSelection != null) {
-      restoreRelativeSelection(editor, relativeSelection);
+    for (const u of updates) {
+      appliedUpdateIdsRef.current.add(u.id);
     }
+    reconcileRef.current(editor, state, updates, node.id);
   }, [state, updates, editor, node.id]);
 
   // Expose flush for the bridge so pending saves are not lost

--- a/apps/mobile/webviews/editor/src/editor.tsx
+++ b/apps/mobile/webviews/editor/src/editor.tsx
@@ -48,9 +48,13 @@ function buildDocState(
   };
 }
 
-function buildDocUpdates(nodeId: string, updates: string[]): DocumentUpdate[] {
+function buildDocUpdates(
+  nodeId: string,
+  updates: string[],
+  startIndex = 0
+): DocumentUpdate[] {
   return updates.map((data, i) => ({
-    id: `${nodeId}-update-${i}`,
+    id: `${nodeId}-update-${startIndex + i}`,
     documentId: nodeId,
     data,
   }));
@@ -90,6 +94,11 @@ export function MobileEditorApp() {
       case 'state.update': {
         const current = editorStateRef.current;
         if (!current) return;
+        const nextUpdates = buildDocUpdates(
+          current.nodeId,
+          msg.payload.updates,
+          current.docUpdates.length
+        );
 
         const updated: EditorState = {
           ...current,
@@ -98,10 +107,8 @@ export function MobileEditorApp() {
             revision: msg.payload.revision,
             state: msg.payload.state,
           },
-          docUpdates: buildDocUpdates(
-            current.nodeId,
-            msg.payload.updates
-          ),
+          // Keep a stable local sequence so incremental batches are distinct.
+          docUpdates: [...current.docUpdates, ...nextUpdates],
         };
         editorStateRef.current = updated;
         setEditorState(updated);

--- a/apps/server/src/api/client/routes/workspaces/users/user-role-update.ts
+++ b/apps/server/src/api/client/routes/workspaces/users/user-role-update.ts
@@ -64,6 +64,45 @@ export const userRoleUpdateRoute: FastifyPluginCallbackZod = (
         });
       }
 
+      // Only owners can modify another owner's role
+      if (
+        userToUpdate.role === 'owner' &&
+        workspace.user.role !== 'owner'
+      ) {
+        return reply.code(403).send({
+          code: ApiErrorCode.UserUpdateNoAccess,
+          message:
+            'Only owners can change the role of another owner.',
+        });
+      }
+
+      // Only owners can promote someone to owner
+      if (input.role === 'owner' && workspace.user.role !== 'owner') {
+        return reply.code(403).send({
+          code: ApiErrorCode.UserUpdateNoAccess,
+          message: 'Only owners can promote users to owner.',
+        });
+      }
+
+      // Prevent removing the last owner
+      if (userToUpdate.role === 'owner' && input.role !== 'owner') {
+        const ownerCount = await database
+          .selectFrom('users')
+          .select(database.fn.countAll<number>().as('count'))
+          .where('workspace_id', '=', workspace.id)
+          .where('role', '=', 'owner')
+          .where('status', '=', UserStatus.Active)
+          .executeTakeFirstOrThrow();
+
+        if (ownerCount.count <= 1) {
+          return reply.code(400).send({
+            code: ApiErrorCode.BadRequest,
+            message:
+              'Cannot remove the last owner. Promote another user to owner first.',
+          });
+        }
+      }
+
       const status =
         input.role === 'none' ? UserStatus.Removed : UserStatus.Active;
 

--- a/packages/core/src/types/auth.ts
+++ b/packages/core/src/types/auth.ts
@@ -3,12 +3,19 @@ import { z } from 'zod/v4';
 import { accountOutputSchema } from '@colanode/core/types/accounts';
 import { workspaceOutputSchema } from '@colanode/core/types/workspaces';
 
+export const newPasswordSchema = z
+  .string({ error: 'Password is required' })
+  .min(8, 'Password must be at least 8 characters')
+  .regex(/[A-Z]/, 'Must contain an uppercase letter')
+  .regex(/[a-z]/, 'Must contain a lowercase letter')
+  .regex(/[^A-Za-z0-9]/, 'Must contain a special character');
+
 export const emailRegisterInputSchema = z.object({
   name: z.string({ error: 'Name is required' }),
   email: z.string({ error: 'Email is required' }).email({
     message: 'Invalid email address',
   }),
-  password: z.string({ error: 'Password is required' }),
+  password: newPasswordSchema,
 });
 
 export type EmailRegisterInput = z.infer<typeof emailRegisterInputSchema>;
@@ -73,7 +80,7 @@ export type EmailPasswordResetInitInput = z.infer<
 export const emailPasswordResetCompleteInputSchema = z.object({
   id: z.string(),
   otp: z.string(),
-  password: z.string(),
+  password: newPasswordSchema,
 });
 
 export type EmailPasswordResetCompleteInput = z.infer<

--- a/packages/ui/src/components/auth/email-password-reset-complete-form.tsx
+++ b/packages/ui/src/components/auth/email-password-reset-complete-form.tsx
@@ -2,6 +2,7 @@ import { useForm } from '@tanstack/react-form';
 import { Lock } from 'lucide-react';
 import { z } from 'zod/v4';
 
+import { newPasswordSchema } from '@colanode/core/types/auth';
 import { Button } from '@colanode/ui/components/ui/button';
 import {
   Field,
@@ -15,15 +16,7 @@ import { useCountdown } from '@colanode/ui/hooks/use-countdown';
 const formSchema = z
   .object({
     otp: z.string().min(6, 'OTP must be 6 characters long'),
-    password: z
-      .string()
-      .min(8, 'Password must be at least 8 characters long')
-      .regex(/[A-Z]/, 'Password must contain at least one uppercase letter')
-      .regex(/[a-z]/, 'Password must contain at least one lowercase letter')
-      .regex(
-        /[^A-Za-z0-9]/,
-        'Password must contain at least one special character'
-      ),
+    password: newPasswordSchema,
     confirmPassword: z.string(),
   })
   .refine((data) => data.password === data.confirmPassword, {

--- a/packages/ui/src/components/auth/email-register-form.tsx
+++ b/packages/ui/src/components/auth/email-register-form.tsx
@@ -2,6 +2,7 @@ import { useForm } from '@tanstack/react-form';
 import { Mail } from 'lucide-react';
 import { z } from 'zod/v4';
 
+import { newPasswordSchema } from '@colanode/core/types/auth';
 import { Button } from '@colanode/ui/components/ui/button';
 import {
   Field,
@@ -15,15 +16,7 @@ const formSchema = z
   .object({
     name: z.string().min(2),
     email: z.string().min(2).email(),
-    password: z
-      .string()
-      .min(8, 'Password must be at least 8 characters long')
-      .regex(/[A-Z]/, 'Password must contain at least one uppercase letter')
-      .regex(/[a-z]/, 'Password must contain at least one lowercase letter')
-      .regex(
-        /[^A-Za-z0-9]/,
-        'Password must contain at least one special character'
-      ),
+    password: newPasswordSchema,
     confirmPassword: z.string(),
   })
   .refine((data) => data.password === data.confirmPassword, {


### PR DESCRIPTION
## Summary
- **Auth validation alignment**: Extracted `newPasswordSchema` into `@colanode/core` and replaced duplicated password rules in mobile, web UI, and server schemas so all platforms enforce the same policy.
- **Workspace/member role hardening**: Restricted workspace editing to owners only, prevented admins from seeing/assigning the owner role, and added server-side guards against owner demotion and last-owner removal.
- **Page editor CRDT reconciliation**: Fixed incremental update tracking so collaborator edits arrive promptly even without a revision bump. Remote updates are now stashed during local pending saves and replayed after flush.
- **File download reliability**: Replaced filesystem-polling download loop with reactive `useLiveQuery` on `local.file.get` status, added a ref-based timeout fallback, and handled download failure state from the server.

## Test plan
- [ ] Register and reset password on mobile — verify validation matches web
- [ ] As admin, confirm workspace edit and owner role options are hidden
- [ ] Edit a page on two clients — verify remote edits appear promptly on mobile
- [ ] Download a file on mobile — verify spinner clears on completion or shows timeout/error

🤖 Generated with [Claude Code](https://claude.com/claude-code)