### PR TITLE
Mobile: database views, record editing, and WebView bridge improvements

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -10,9 +10,9 @@ Colanode Mobile is an Expo + React Native client for Colanode's local-first coll
 - `@colanode/client` for local database access, queries, mutations, and sync
 - `@colanode/core` for schemas, types, permissions, and business rules
 - `@colanode/crdt` for Yjs-backed collaborative documents
-- `@colanode/ui` for shared editor behavior and UI building blocks where it makes sense
+- `@colanode/ui` for shared editor behavior, database components, and UI building blocks where it makes sense
 
-The app is mostly native React Native UI. The main exception is page editing: the rich-text editor runs as a small browser app inside a `WebView`, while the surrounding shell, routing, data access, and native integrations stay in React Native.
+The app is mostly native React Native UI. The main exception is content editing: the rich-text editor, database views, and record detail screens run as a browser app inside a `WebView`, while the surrounding shell, routing, data access, and native integrations stay in React Native.
 
 ## Architecture
 
@@ -41,7 +41,7 @@ graph TB
 
     Web --> Core & Client & CRDT & UI
     Desktop --> Core & Client & CRDT & UI
-    Mobile --> Core & Client & CRDT
+    Mobile --> Core & Client & CRDT & UI
 
     Web -- "HTTP + WS" --> API
     Desktop -- "HTTP + WS" --> API
@@ -76,19 +76,21 @@ sequenceDiagram
     Screen-->>User: UI refreshes
 ```
 
-### How the embedded page editor works
+### How the embedded editor WebView works
+
+The WebView hosts three rendering modes — page editing, database views, and record detail — all sharing the same bridge and communication protocol.
 
 ```mermaid
 sequenceDiagram
-    participant Page as Native Page Screen
-    participant WV as WebView (TipTap)
+    participant Screen as Native Screen
+    participant WV as WebView
     participant Bridge as Bridge Messages
     participant App as AppService
 
-    Page->>WV: Load editor.html asset
+    Screen->>WV: Load editor.html asset
     WV->>Bridge: "ready"
-    Page->>WV: Send CRDT state + theme + permissions
-    WV->>WV: Render TipTap editor
+    Screen->>WV: init (mode, CRDT state, theme, permissions)
+    WV->>WV: Render based on mode:<br/>page → TipTap editor<br/>database → database table view<br/>record → record attributes + editor
 
     loop User edits
         WV->>Bridge: mutation.request
@@ -97,20 +99,25 @@ sequenceDiagram
         Bridge-->>WV: mutation.response
     end
 
-    WV->>Bridge: query.request (e.g. node lookup)
-    Bridge->>App: Execute query
-    App-->>Bridge: Result
-    Bridge-->>WV: query.response
+    loop Data subscriptions
+        WV->>Bridge: query.subscribe.request
+        Bridge->>App: Subscribe via mediator
+        App-->>Bridge: Initial data
+        App->>Bridge: event.publish (live updates)
+        Bridge-->>WV: Collection updates
+    end
 
-    Note over Page,WV: CRDT updates debounced (500ms),<br/>flushed on background/navigate
+    Note over Screen,WV: CRDT updates debounced (500ms),<br/>flushed on background/navigate
 ```
 
 ## What Exists Today
 
 - **Authentication:** server selection, OTP login, registration, password reset
 - **Messaging:** chat and channel browsing, message sending, replies, reactions, editing, deletion
-- **Content:** spaces, folders, files, pages, and workspace navigation
-- **Page editing:** inline rich-text editing via embedded TipTap WebView (paragraph, headings, lists, tasks, blockquotes, horizontal rules)
+- **Content:** spaces, folders, files, pages, databases, records, and workspace navigation
+- **Page editing:** inline rich-text editing via embedded TipTap WebView (paragraph, headings, lists, tasks, blockquotes, code blocks, tables, horizontal rules, inline databases)
+- **Database views:** table view with inline field editing, record creation, view tabs, filters, sorts, and settings — rendered inside the WebView using shared `@colanode/ui` database components
+- **Record editing:** record attributes (name, fields) and rich-text body editing, also rendered in the WebView
 - **File management:** file picking, upload (resumable via tus-js-client), download, and preview
 - **Workspaces:** workspace switching, creation, and basic settings
 - **Members:** member list, invite flow with email chips and role picker
@@ -144,7 +151,7 @@ npm run android   # Android Emulator
 npm run start     # Expo dev server only
 ```
 
-The `prestart`, `preios`, and `preandroid` scripts build and copy the embedded page editor asset before Expo starts.
+The `prestart`, `preios`, and `preandroid` scripts build and copy the embedded editor asset before Expo starts.
 
 ## Project Structure
 
@@ -172,6 +179,8 @@ apps/mobile/
 │       │   ├── space/[spaceId].tsx    #   Space children browser
 │       │   ├── channel/[channelId].tsx#   Channel messages
 │       │   ├── page/[pageId]/         #   Page viewer/editor (WebView)
+│       │   ├── database/[databaseId].tsx # Database view (WebView)
+│       │   ├── record/[recordId].tsx  #   Record detail + editor (WebView)
 │       │   ├── file/[fileId].tsx      #   File preview/download
 │       │   └── folder/[folderId].tsx  #   Folder contents
 │       └── (settings)/                # Settings tab
@@ -202,8 +211,16 @@ apps/mobile/
 │   ├── lib/                           # Crypto polyfill, colors, query client, utils
 │   └── mocks/                         # Metro mocks for browser-only modules
 ├── webviews/
-│   └── editor/                        # Embedded TipTap editor (separate Vite build)
-│       ├── src/                       # Editor app: bridge, extensions, views
+│   └── editor/                        # Embedded editor (separate Vite build)
+│       ├── src/
+│       │   ├── main.tsx               # Bootstrap: lazy-loads bridge + editor
+│       │   ├── bridge.ts             # Native ↔ WebView message protocol
+│       │   ├── editor.tsx            # Root component: mode routing, contexts, keyboard
+│       │   ├── document-editor.tsx   # TipTap rich-text editor (page/record body)
+│       │   ├── database-runtime.tsx  # Database table view (mobile-specific layout)
+│       │   ├── record-runtime.tsx    # Record attributes + document editor
+│       │   ├── extensions/           # TipTap node extensions (database, page, file, folder)
+│       │   └── views/               # TipTap node views (database, page, file, folder, mention)
 │       ├── vite.config.ts             # Builds to single HTML file
 │       └── editor.html                # Entry HTML
 ├── assets/
@@ -220,7 +237,7 @@ apps/mobile/
 
 ### 1. Native mobile shell
 
-The Expo / React Native app handles everything except the rich-text editor DOM:
+The Expo / React Native app handles everything except the rich-text and database editor DOM:
 
 - File-based routing via Expo Router with `(auth)` and `(app)` route groups
 - Tab navigation: Home, Spaces, Chats, Settings
@@ -240,18 +257,33 @@ The mobile app follows the same local-first model as the desktop and web clients
 
 This is why mobile can reuse `@colanode/client`, `@colanode/core`, and `@colanode/crdt` instead of reimplementing business logic.
 
-### 3. Embedded page editor
+### 3. Embedded editor WebView
 
-Rich-text page editing is implemented as an embedded browser app loaded into a React Native `WebView`.
+Rich-text editing, database views, and record detail screens are implemented as an embedded browser app loaded into a React Native `WebView`.
 
 Why:
 
 - The shared editor stack (TipTap / ProseMirror) depends on DOM APIs
-- React Native cannot run DOM-based editor code directly
+- Database and record UIs use `@colanode/ui` components built with Radix UI, TanStack DB, and Tailwind CSS — all browser-only
+- React Native cannot run DOM-based editor or UI code directly
 - A WebView gives the app a browser runtime inside the native screen
-- This lets mobile reuse the mature shared web editor instead of maintaining a second implementation
+- This lets mobile reuse the shared web components instead of maintaining parallel implementations
 
 The editor lives in `webviews/editor/`, has its own Vite build, and produces a single HTML file that Metro bundles as an asset. The native `PageWebView` component loads it and communicates via a bidirectional message bridge.
+
+The WebView operates in three modes:
+
+| Mode | Renders | Used by |
+|---|---|---|
+| `page` | TipTap rich-text editor with inline database blocks | `page/[pageId]` |
+| `database` | Database table view with view tabs, filters, sorts | `database/[databaseId]` |
+| `record` | Record attributes (name, fields) + TipTap body editor | `record/[recordId]` |
+
+### 4. Database and record rendering
+
+Database views and record editing run inside the WebView and use shared `@colanode/ui` components (database table, record attributes, field value editors, view settings, etc.) via TanStack DB collections that communicate with native through the bridge.
+
+The WebView's `database-runtime.tsx` intentionally reimplements some of the surrounding table/view/header layout rather than reusing the full shared `DatabaseViews` component from `packages/ui`. This is because the shared components include desktop-specific features (drag-and-drop column reordering, column resizing, board/calendar layouts) that don't work well on mobile. The mobile-specific layout provides a touch-friendly table view while still reusing the shared data layer, field value components, and database context providers. Consolidating these into a single responsive implementation in `packages/ui` is a future goal.
 
 ## Metro Configuration
 
@@ -266,7 +298,7 @@ The custom `index.js` entry point loads `crypto-polyfill.ts` before anything els
 
 ## Working On The Embedded Editor
 
-Browser-side editor code lives in `webviews/editor/src/`. Native hosting and bridge code lives in `src/components/pages/page-webview.tsx`. The native page screen is at `app/(app)/(spaces)/page/[pageId]/index.tsx`.
+Browser-side editor code lives in `webviews/editor/src/`. Native hosting and bridge code lives in `src/components/pages/page-webview.tsx`. The native screens are at `app/(app)/(spaces)/page/[pageId]/index.tsx`, `database/[databaseId].tsx`, and `record/[recordId].tsx`.
 
 ```bash
 # Rebuild the editor after changes
@@ -282,8 +314,10 @@ The bridge protocol supports:
 
 | Direction | Messages |
 |---|---|
-| Native → WebView | `init`, `state.update`, `theme.change`, `permission.change`, `flush`, `block.command`, keyboard events |
-| WebView → Native | `ready`, `mutation.request`, `query.request`, `navigate.node`, `navigate.url`, `editor.focus`, `error` |
+| Native → WebView | `init`, `state.update`, `theme.change`, `permission.change`, `flush`, `block.command`, `keyboard.show`, `keyboard.hide`, `editor.blur`, `event.publish` |
+| WebView → Native | `ready`, `mutation.request`, `query.request`, `query.subscribe.request`, `query.unsubscribe.request`, `navigate.node`, `navigate.url`, `editor.focus`, `error` |
+
+The WebView uses TanStack DB collections for reactive data access. Collections subscribe to queries via the bridge (`query.subscribe.request`) and receive live updates through forwarded events (`event.publish`). This gives database and record views the same reactive behavior as the web/desktop apps.
 
 ## Dependencies
 
@@ -301,7 +335,8 @@ The bridge protocol supports:
 
 - The app is still evolving quickly, so some flows are intentionally incomplete.
 - The page title is managed by the native screen header, while the document body is managed by the embedded editor.
-- Using a WebView for the editor adds build/bridge complexity, but lets the app reuse the mature shared web editor stack instead of maintaining a second rich-text editor in pure React Native.
+- Using a WebView for the editor and database views adds build/bridge complexity, but lets the app reuse the shared web component stack instead of maintaining parallel implementations in pure React Native.
+- Database views on mobile currently support the table layout only. Board and calendar layouts are not available on mobile and the view shows a message directing users to switch to a table view.
+- The mobile `database-runtime.tsx` reimplements some table/view layout that exists in shared `packages/ui` because the shared version includes desktop-specific drag-and-drop and resize features. Consolidating into a responsive shared implementation is planned for the future.
 - No inline mark editing (bold/italic) in the editor yet — plain text formatting per block only.
-- No database views on mobile (complex, poor mobile UX).
 - No push notifications yet.

--- a/apps/mobile/app/(app)/(spaces)/database/[databaseId].tsx
+++ b/apps/mobile/app/(app)/(spaces)/database/[databaseId].tsx
@@ -1,8 +1,6 @@
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
-  AppState,
-  AppStateStatus,
   Keyboard,
   KeyboardAvoidingView,
   Platform,
@@ -13,86 +11,33 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { LocalPageNode } from '@colanode/client/types/nodes';
-import { SkeletonPage } from '@colanode/mobile/components/ui/skeleton';
+import { LocalDatabaseNode } from '@colanode/client/types/nodes';
 import { RenameNodeSheet } from '@colanode/mobile/components/nodes/rename-node-sheet';
-import { PageBlockTypeSheet } from '@colanode/mobile/components/pages/page-block-type-sheet';
-import { PageEditorToolbar } from '@colanode/mobile/components/pages/page-editor-toolbar';
 import {
   PageWebView,
   type PageWebViewHandle,
 } from '@colanode/mobile/components/pages/page-webview';
 import { BackButton } from '@colanode/mobile/components/ui/back-button';
+import { SkeletonPage } from '@colanode/mobile/components/ui/skeleton';
 import { useTheme } from '@colanode/mobile/contexts/theme';
 import { useWorkspace } from '@colanode/mobile/contexts/workspace';
-import { useLiveQuery } from '@colanode/mobile/hooks/use-live-query';
 import { useNodeQuery } from '@colanode/mobile/hooks/use-node-query';
 import { useNodeRole } from '@colanode/mobile/hooks/use-node-role';
 import { navigateToNodeByType } from '@colanode/mobile/lib/navigation-utils';
 
-export default function PageScreen() {
-  const { pageId } = useLocalSearchParams<{ pageId: string }>();
+export default function DatabaseScreen() {
+  const { databaseId } = useLocalSearchParams<{ databaseId: string }>();
   const router = useRouter();
+  const insets = useSafeAreaInsets();
   const { userId, accountId, workspaceId, role } = useWorkspace();
   const { colors } = useTheme();
-  const insets = useSafeAreaInsets();
-  const webViewRef = useRef<PageWebViewHandle>(null);
-
-  const { data: page, isLoading: pageLoading } =
-    useNodeQuery<LocalPageNode>(userId, pageId, 'page');
-  const { canEdit, isLoading: roleLoading } = useNodeRole(userId, page);
   const [showRename, setShowRename] = useState(false);
   const [keyboardHeight, setKeyboardHeight] = useState(0);
-  const [editorFocused, setEditorFocused] = useState(false);
-  const [showBlockTypes, setShowBlockTypes] = useState(false);
+  const webViewRef = useRef<PageWebViewHandle>(null);
 
-  const { data: docState, isLoading: stateLoading } = useLiveQuery({
-    type: 'document.state.get',
-    documentId: pageId!,
-    userId,
-  });
-
-  const { data: docUpdates, isLoading: updatesLoading } = useLiveQuery({
-    type: 'document.updates.list',
-    documentId: pageId!,
-    userId,
-  });
-
-  // Track keyboard height
-  useEffect(() => {
-    const showEvent =
-      Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
-    const hideEvent =
-      Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
-    const showSub = Keyboard.addListener(showEvent, (e) =>
-      setKeyboardHeight(e.endCoordinates.height)
-    );
-    const hideSub = Keyboard.addListener(hideEvent, () =>
-      setKeyboardHeight(0)
-    );
-    return () => {
-      showSub.remove();
-      hideSub.remove();
-    };
-  }, []);
-
-  // Flush on app background
-  useEffect(() => {
-    const handleAppState = (nextState: AppStateStatus) => {
-      if (nextState === 'background' || nextState === 'inactive') {
-        webViewRef.current?.flush();
-      }
-    };
-    const sub = AppState.addEventListener('change', handleAppState);
-    return () => sub.remove();
-  }, []);
-
-  // Flush on unmount
-  useEffect(() => {
-    return () => {
-      webViewRef.current?.flush();
-    };
-  }, []);
+  const { data: database, isLoading: databaseLoading } =
+    useNodeQuery<LocalDatabaseNode>(userId, databaseId, 'database');
+  const { canEdit, isLoading: roleLoading } = useNodeRole(userId, database);
 
   const handleNavigateNode = useCallback(
     (nodeId: string, nodeType: string) => {
@@ -101,10 +46,24 @@ export default function PageScreen() {
     [router]
   );
 
-  const isLoading = pageLoading || roleLoading || stateLoading || updatesLoading;
-  const showToolbar = (keyboardHeight > 0 && editorFocused && canEdit) || showBlockTypes;
+  useEffect(() => {
+    const showEvent =
+      Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+    const hideEvent =
+      Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
 
-  if (isLoading) {
+    const showSub = Keyboard.addListener(showEvent, (event) =>
+      setKeyboardHeight(event.endCoordinates.height)
+    );
+    const hideSub = Keyboard.addListener(hideEvent, () => setKeyboardHeight(0));
+
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
+  }, []);
+
+  if (databaseLoading || roleLoading) {
     return <SkeletonPage />;
   }
 
@@ -121,7 +80,7 @@ export default function PageScreen() {
         ]}
       >
         <BackButton onPress={() => router.back()} />
-        {canEdit && page ? (
+        {canEdit && database ? (
           <Pressable
             onPress={() => setShowRename(true)}
             style={styles.headerTitleContainer}
@@ -130,7 +89,7 @@ export default function PageScreen() {
               style={[styles.headerTitle, { color: colors.text }]}
               numberOfLines={1}
             >
-              {page.name || 'Page'}
+              {database.name || 'Database'}
             </Text>
           </Pressable>
         ) : (
@@ -139,7 +98,7 @@ export default function PageScreen() {
               style={[styles.headerTitle, { color: colors.text }]}
               numberOfLines={1}
             >
-              {page?.name ?? 'Page'}
+              {database?.name ?? 'Database'}
             </Text>
           </View>
         )}
@@ -148,36 +107,25 @@ export default function PageScreen() {
       <View style={styles.content}>
         <PageWebView
           ref={webViewRef}
-          nodeId={pageId!}
+          mode="database"
+          nodeId={databaseId!}
           userId={userId}
           accountId={accountId}
           workspaceId={workspaceId}
           workspaceRole={role}
-          rootId={page?.rootId ?? ''}
+          rootId={database?.rootId ?? ''}
           canEdit={canEdit}
-          title={page?.name ?? ''}
-          state={docState}
-          updates={docUpdates ?? []}
+          title={database?.name ?? ''}
+          state={null}
+          updates={[]}
           keyboardHeight={keyboardHeight}
           onNavigateNode={handleNavigateNode}
-          onEditorFocusChange={setEditorFocused}
         />
       </View>
-      <PageBlockTypeSheet
-        visible={showBlockTypes}
-        onClose={() => setShowBlockTypes(false)}
-        onSelect={(command) => webViewRef.current?.executeBlockCommand(command)}
-      />
-      {showToolbar && (
-        <PageEditorToolbar
-          onPlusPress={() => setShowBlockTypes(!showBlockTypes)}
-          onDismiss={() => webViewRef.current?.blur()}
-        />
-      )}
-      {page && (
+      {database && (
         <RenameNodeSheet
           visible={showRename}
-          node={page}
+          node={database}
           userId={userId}
           onClose={() => setShowRename(false)}
         />

--- a/apps/mobile/app/(app)/(spaces)/record/[recordId].tsx
+++ b/apps/mobile/app/(app)/(spaces)/record/[recordId].tsx
@@ -6,23 +6,21 @@ import {
   Keyboard,
   KeyboardAvoidingView,
   Platform,
-  Pressable,
   StyleSheet,
   Text,
   View,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { LocalPageNode } from '@colanode/client/types/nodes';
-import { SkeletonPage } from '@colanode/mobile/components/ui/skeleton';
-import { RenameNodeSheet } from '@colanode/mobile/components/nodes/rename-node-sheet';
-import { PageBlockTypeSheet } from '@colanode/mobile/components/pages/page-block-type-sheet';
-import { PageEditorToolbar } from '@colanode/mobile/components/pages/page-editor-toolbar';
+import { LocalRecordNode } from '@colanode/client/types/nodes';
 import {
   PageWebView,
   type PageWebViewHandle,
 } from '@colanode/mobile/components/pages/page-webview';
+import { PageBlockTypeSheet } from '@colanode/mobile/components/pages/page-block-type-sheet';
+import { PageEditorToolbar } from '@colanode/mobile/components/pages/page-editor-toolbar';
 import { BackButton } from '@colanode/mobile/components/ui/back-button';
+import { SkeletonPage } from '@colanode/mobile/components/ui/skeleton';
 import { useTheme } from '@colanode/mobile/contexts/theme';
 import { useWorkspace } from '@colanode/mobile/contexts/workspace';
 import { useLiveQuery } from '@colanode/mobile/hooks/use-live-query';
@@ -30,64 +28,68 @@ import { useNodeQuery } from '@colanode/mobile/hooks/use-node-query';
 import { useNodeRole } from '@colanode/mobile/hooks/use-node-role';
 import { navigateToNodeByType } from '@colanode/mobile/lib/navigation-utils';
 
-export default function PageScreen() {
-  const { pageId } = useLocalSearchParams<{ pageId: string }>();
+export default function RecordScreen() {
+  const { recordId } = useLocalSearchParams<{ recordId: string }>();
   const router = useRouter();
   const { userId, accountId, workspaceId, role } = useWorkspace();
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
   const webViewRef = useRef<PageWebViewHandle>(null);
 
-  const { data: page, isLoading: pageLoading } =
-    useNodeQuery<LocalPageNode>(userId, pageId, 'page');
-  const { canEdit, isLoading: roleLoading } = useNodeRole(userId, page);
-  const [showRename, setShowRename] = useState(false);
+  const { data: record, isLoading: recordLoading } =
+    useNodeQuery<LocalRecordNode>(userId, recordId, 'record');
+  const { canEdit: roleCanEdit, isLoading: roleLoading } = useNodeRole(
+    userId,
+    record
+  );
+  const canEdit = record
+    ? record.createdBy === userId || roleCanEdit
+    : roleCanEdit;
+
   const [keyboardHeight, setKeyboardHeight] = useState(0);
   const [editorFocused, setEditorFocused] = useState(false);
   const [showBlockTypes, setShowBlockTypes] = useState(false);
 
   const { data: docState, isLoading: stateLoading } = useLiveQuery({
     type: 'document.state.get',
-    documentId: pageId!,
+    documentId: recordId!,
     userId,
   });
 
   const { data: docUpdates, isLoading: updatesLoading } = useLiveQuery({
     type: 'document.updates.list',
-    documentId: pageId!,
+    documentId: recordId!,
     userId,
   });
 
-  // Track keyboard height
   useEffect(() => {
     const showEvent =
       Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
     const hideEvent =
       Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
-    const showSub = Keyboard.addListener(showEvent, (e) =>
-      setKeyboardHeight(e.endCoordinates.height)
+
+    const showSub = Keyboard.addListener(showEvent, (event) =>
+      setKeyboardHeight(event.endCoordinates.height)
     );
-    const hideSub = Keyboard.addListener(hideEvent, () =>
-      setKeyboardHeight(0)
-    );
+    const hideSub = Keyboard.addListener(hideEvent, () => setKeyboardHeight(0));
+
     return () => {
       showSub.remove();
       hideSub.remove();
     };
   }, []);
 
-  // Flush on app background
   useEffect(() => {
     const handleAppState = (nextState: AppStateStatus) => {
       if (nextState === 'background' || nextState === 'inactive') {
         webViewRef.current?.flush();
       }
     };
-    const sub = AppState.addEventListener('change', handleAppState);
-    return () => sub.remove();
+
+    const subscription = AppState.addEventListener('change', handleAppState);
+    return () => subscription.remove();
   }, []);
 
-  // Flush on unmount
   useEffect(() => {
     return () => {
       webViewRef.current?.flush();
@@ -101,8 +103,10 @@ export default function PageScreen() {
     [router]
   );
 
-  const isLoading = pageLoading || roleLoading || stateLoading || updatesLoading;
-  const showToolbar = (keyboardHeight > 0 && editorFocused && canEdit) || showBlockTypes;
+  const isLoading =
+    recordLoading || roleLoading || stateLoading || updatesLoading;
+  const showToolbar =
+    (keyboardHeight > 0 && editorFocused && canEdit) || showBlockTypes;
 
   if (isLoading) {
     return <SkeletonPage />;
@@ -121,41 +125,28 @@ export default function PageScreen() {
         ]}
       >
         <BackButton onPress={() => router.back()} />
-        {canEdit && page ? (
-          <Pressable
-            onPress={() => setShowRename(true)}
-            style={styles.headerTitleContainer}
+        <View style={styles.headerTitleContainer}>
+          <Text
+            style={[styles.headerTitle, { color: colors.text }]}
+            numberOfLines={1}
           >
-            <Text
-              style={[styles.headerTitle, { color: colors.text }]}
-              numberOfLines={1}
-            >
-              {page.name || 'Page'}
-            </Text>
-          </Pressable>
-        ) : (
-          <View style={styles.headerTitleContainer}>
-            <Text
-              style={[styles.headerTitle, { color: colors.text }]}
-              numberOfLines={1}
-            >
-              {page?.name ?? 'Page'}
-            </Text>
-          </View>
-        )}
+            {record?.name ?? 'Record'}
+          </Text>
+        </View>
         <View style={styles.headerSpacer} />
       </View>
       <View style={styles.content}>
         <PageWebView
           ref={webViewRef}
-          nodeId={pageId!}
+          mode="record"
+          nodeId={recordId!}
           userId={userId}
           accountId={accountId}
           workspaceId={workspaceId}
           workspaceRole={role}
-          rootId={page?.rootId ?? ''}
+          rootId={record?.rootId ?? ''}
           canEdit={canEdit}
-          title={page?.name ?? ''}
+          title={record?.name ?? ''}
           state={docState}
           updates={docUpdates ?? []}
           keyboardHeight={keyboardHeight}
@@ -172,14 +163,6 @@ export default function PageScreen() {
         <PageEditorToolbar
           onPlusPress={() => setShowBlockTypes(!showBlockTypes)}
           onDismiss={() => webViewRef.current?.blur()}
-        />
-      )}
-      {page && (
-        <RenameNodeSheet
-          visible={showRename}
-          node={page}
-          userId={userId}
-          onClose={() => setShowRename(false)}
         />
       )}
     </KeyboardAvoidingView>

--- a/apps/mobile/scripts/copy-editor.js
+++ b/apps/mobile/scripts/copy-editor.js
@@ -6,27 +6,67 @@
  * stale assets cannot sneak through.
  */
 
-const { cpSync, existsSync, mkdirSync, statSync } = require('node:fs');
+const {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  statSync,
+} = require('node:fs');
 const { resolve } = require('node:path');
 const { execSync } = require('node:child_process');
 
 const editorDir = resolve(__dirname, '../webviews/editor');
+const editorSrcDir = resolve(editorDir, 'src');
+const editorHtmlFile = resolve(editorDir, 'editor.html');
+const editorPackageFile = resolve(editorDir, 'package.json');
+const editorTsConfigFile = resolve(editorDir, 'tsconfig.json');
+const editorViteConfigFile = resolve(editorDir, 'vite.config.ts');
 const srcFile = resolve(editorDir, 'dist/editor.html');
 const destDir = resolve(__dirname, '../assets/editor-dist');
 const destFile = resolve(destDir, 'editor.html');
 
+function getLatestMtimeMs(path) {
+  const stats = statSync(path);
+  if (!stats.isDirectory()) {
+    return stats.mtimeMs;
+  }
+
+  let latest = stats.mtimeMs;
+  for (const entry of readdirSync(path, { withFileTypes: true })) {
+    latest = Math.max(latest, getLatestMtimeMs(resolve(path, entry.name)));
+  }
+
+  return latest;
+}
+
+function editorSourceMtimeMs() {
+  return Math.max(
+    getLatestMtimeMs(editorSrcDir),
+    getLatestMtimeMs(editorHtmlFile),
+    getLatestMtimeMs(editorPackageFile),
+    getLatestMtimeMs(editorTsConfigFile),
+    getLatestMtimeMs(editorViteConfigFile)
+  );
+}
+
 function needsBuild() {
   if (!existsSync(srcFile)) return true;
+  return editorSourceMtimeMs() > statSync(srcFile).mtimeMs;
+}
+
+function needsCopy() {
+  if (!existsSync(srcFile)) return false;
   if (!existsSync(destFile)) return true;
-  // Rebuild when source is newer than the copied asset
   return statSync(srcFile).mtimeMs > statSync(destFile).mtimeMs;
 }
 
 if (needsBuild()) {
-  if (!existsSync(srcFile)) {
-    console.log('[copy-editor] Building @colanode/mobile-editor...');
-    execSync('npm run build', { cwd: editorDir, stdio: 'inherit' });
-  }
+  console.log('[copy-editor] Building @colanode/mobile-editor...');
+  execSync('npm run build', { cwd: editorDir, stdio: 'inherit' });
+}
+
+if (needsCopy()) {
   mkdirSync(destDir, { recursive: true });
   cpSync(srcFile, destFile);
   console.log('[copy-editor] Copied editor.html to assets/editor-dist/');

--- a/apps/mobile/src/components/pages/page-block-type-sheet.tsx
+++ b/apps/mobile/src/components/pages/page-block-type-sheet.tsx
@@ -21,6 +21,8 @@ const BLOCK_TYPES: BlockType[] = [
   { command: 'codeBlock', label: 'Code', icon: 'code' },
   { command: 'divider', label: 'Divider', icon: 'minus' },
   { command: 'table', label: 'Table', icon: 'grid' },
+  { command: 'databaseInline', label: 'Database', icon: 'grid' },
+  { command: 'database', label: 'Database Page', icon: 'grid' },
 ];
 
 interface PageBlockTypeSheetProps {

--- a/apps/mobile/src/components/pages/page-webview.tsx
+++ b/apps/mobile/src/components/pages/page-webview.tsx
@@ -16,7 +16,9 @@ import {
 } from 'react-native';
 import { WebView, type WebViewMessageEvent } from 'react-native-webview';
 
-import type { DocumentState, DocumentUpdate } from '@colanode/client/types';
+import { eventBus } from '@colanode/client/lib';
+import type { Event, DocumentState, DocumentUpdate } from '@colanode/client/types';
+import type { WorkspaceRole } from '@colanode/core';
 import { useAppService } from '@colanode/mobile/contexts/app-service';
 import { useTheme } from '@colanode/mobile/contexts/theme';
 
@@ -30,10 +32,12 @@ export interface PageWebViewHandle {
 }
 
 interface PageWebViewProps {
+  mode?: 'page' | 'database' | 'record';
   nodeId: string;
   userId: string;
   accountId: string;
   workspaceId: string;
+  workspaceRole: WorkspaceRole;
   rootId: string;
   canEdit: boolean;
   title: string;
@@ -44,13 +48,18 @@ interface PageWebViewProps {
   onEditorFocusChange?: (focused: boolean) => void;
 }
 
+const buildPendingSubscriptionKey = (windowId: string, key: string) =>
+  `${windowId}:${key}`;
+
 export const PageWebView = forwardRef<PageWebViewHandle, PageWebViewProps>(
   (
     {
+      mode = 'page',
       nodeId,
       userId,
       accountId,
       workspaceId,
+      workspaceRole,
       rootId,
       canEdit,
       title,
@@ -66,10 +75,34 @@ export const PageWebView = forwardRef<PageWebViewHandle, PageWebViewProps>(
   const { scheme, colors } = useTheme();
   const webViewRef = useRef<WebView>(null);
   const isReadyRef = useRef(false);
+  const editorFocusedRef = useRef(false);
+  const webViewWindowIdRef = useRef(
+    `mobile-webview:${mode}:${nodeId}:${Math.random().toString(36).slice(2)}`
+  );
+  const subscribedQueryKeysRef = useRef<Set<string>>(new Set());
+  const pendingUnsubscribeKeysRef = useRef<Set<string>>(new Set());
   const revisionRef = useRef(state?.revision ?? '0');
   const sentUpdateIdsRef = useRef<Set<string>>(new Set());
-  const [editorHtml, setEditorHtml] = useState<string | null>(null);
+  const [editorAsset, setEditorAsset] = useState<{ html: string; baseUrl: string } | null>(null);
   const [webViewReady, setWebViewReady] = useState(false);
+
+  useEffect(() => {
+    const previousWindowId = webViewWindowIdRef.current;
+    for (const key of subscribedQueryKeysRef.current) {
+      pendingUnsubscribeKeysRef.current.add(
+        buildPendingSubscriptionKey(previousWindowId, key)
+      );
+      appService.mediator.unsubscribeQuery(key, previousWindowId);
+    }
+
+    subscribedQueryKeysRef.current.clear();
+    webViewWindowIdRef.current = `mobile-webview:${mode}:${nodeId}:${Math.random().toString(36).slice(2)}`;
+    isReadyRef.current = false;
+    editorFocusedRef.current = false;
+    setWebViewReady(false);
+    revisionRef.current = '0';
+    sentUpdateIdsRef.current.clear();
+  }, [appService, mode, nodeId]);
 
   // Load the HTML content from the asset
   useEffect(() => {
@@ -80,13 +113,16 @@ export const PageWebView = forwardRef<PageWebViewHandle, PageWebViewProps>(
         const resp = await fetch(asset.localUri);
         let html = await resp.text();
         // Polyfill crypto.randomUUID — iOS WebView doesn't provide it
-        const polyfill = `<script>if(!crypto.randomUUID){crypto.randomUUID=function(){var d=new Uint8Array(16);crypto.getRandomValues(d);d[6]=(d[6]&0x0f)|0x40;d[8]=(d[8]&0x3f)|0x80;var h='';for(var i=0;i<16;i++){h+=d[i].toString(16).padStart(2,'0');if(i===3||i===5||i===7||i===9)h+='-';}return h;};}</script>`;
+        const polyfill = `<script>(function(){if(typeof window.crypto==='undefined'){window.crypto={};}if(typeof window.crypto.getRandomValues!=='function'){window.crypto.getRandomValues=function(arr){for(var i=0;i<arr.length;i++){arr[i]=Math.floor(Math.random()*256);}return arr;};}if(typeof window.crypto.randomUUID!=='function'){window.crypto.randomUUID=function(){var d=new Uint8Array(16);window.crypto.getRandomValues(d);d[6]=(d[6]&0x0f)|0x40;d[8]=(d[8]&0x3f)|0x80;var h='';for(var i=0;i<16;i++){h+=d[i].toString(16).padStart(2,'0');if(i===3||i===5||i===7||i===9)h+='-';}return h;};}})();</script>`;
         html = html.replace('<head>', '<head>' + polyfill);
         // Apply dark class before first paint to avoid white flash
         if (scheme === 'dark') {
           html = html.replace('<html lang="en">', '<html lang="en" class="dark">');
         }
-        setEditorHtml(html);
+        // Derive base URL from the asset path so the page gets a file:// origin.
+        // Without a real origin, WKWebView masks all error details as "Script error".
+        const baseUrl = asset.localUri.replace(/\/[^/]*$/, '/');
+        setEditorAsset({ html, baseUrl });
       }
     };
     loadAsset();
@@ -96,7 +132,7 @@ export const PageWebView = forwardRef<PageWebViewHandle, PageWebViewProps>(
     if (!webViewRef.current) return;
     const json = JSON.stringify(msg);
     webViewRef.current.injectJavaScript(
-      `(function(){try{window.dispatchEvent(new MessageEvent('message',{data:${JSON.stringify(json)}}));}catch(e){}})();true;`
+      `(function(){try{window.dispatchEvent(new MessageEvent('message',{data:${JSON.stringify(json)}}));}catch(e){window.__colanodeBridgeReportError&&window.__colanodeBridgeReportError('Bridge dispatch error',e);}})();true;`
     );
   }, []);
 
@@ -104,10 +140,12 @@ export const PageWebView = forwardRef<PageWebViewHandle, PageWebViewProps>(
     sendMessage({
       type: 'init',
       payload: {
+        mode,
         nodeId,
         userId,
         accountId,
         workspaceId,
+        workspaceRole,
         rootId,
         canEdit,
         theme: scheme,
@@ -120,9 +158,11 @@ export const PageWebView = forwardRef<PageWebViewHandle, PageWebViewProps>(
     sentUpdateIdsRef.current = new Set(updates.map((u) => u.id));
   }, [
     nodeId,
+    mode,
     userId,
     accountId,
     workspaceId,
+    workspaceRole,
     rootId,
     canEdit,
     scheme,
@@ -131,6 +171,23 @@ export const PageWebView = forwardRef<PageWebViewHandle, PageWebViewProps>(
     title,
     sendMessage,
   ]);
+
+  useEffect(() => {
+    const subscriptionId = eventBus.subscribe((event: Event) => {
+      if (!isReadyRef.current) {
+        return;
+      }
+
+      sendMessage({
+        type: 'event.publish',
+        payload: { event },
+      });
+    });
+
+    return () => {
+      eventBus.unsubscribe(subscriptionId);
+    };
+  }, [sendMessage]);
 
   // Send state updates when revision changes or new updates arrive
   useEffect(() => {
@@ -181,6 +238,7 @@ export const PageWebView = forwardRef<PageWebViewHandle, PageWebViewProps>(
     if (!isReadyRef.current) return;
     if (prevKeyboardHeight.current === keyboardHeight) return;
     prevKeyboardHeight.current = keyboardHeight;
+    if (!editorFocusedRef.current) return;
     if (keyboardHeight > 0) {
       sendMessage({ type: 'keyboard.show', payload: { height: keyboardHeight } });
     } else {
@@ -295,8 +353,74 @@ export const PageWebView = forwardRef<PageWebViewHandle, PageWebViewProps>(
           break;
         }
 
+        case 'query.subscribe.request': {
+          const { requestId, key, input } = msg.payload as {
+            requestId: string;
+            key: string;
+            input: Record<string, unknown>;
+          };
+
+          const queryInput = { ...input };
+          if (!queryInput.userId) {
+            queryInput.userId = userId;
+          }
+
+          try {
+            const windowId = webViewWindowIdRef.current;
+            const pendingKey = buildPendingSubscriptionKey(windowId, key);
+
+            pendingUnsubscribeKeysRef.current.delete(pendingKey);
+            subscribedQueryKeysRef.current.add(key);
+            const data = await appService.mediator.executeQueryAndSubscribe(
+              key,
+              windowId,
+              queryInput as never
+            );
+
+            if (pendingUnsubscribeKeysRef.current.has(pendingKey)) {
+              pendingUnsubscribeKeysRef.current.delete(pendingKey);
+              subscribedQueryKeysRef.current.delete(key);
+              appService.mediator.unsubscribeQuery(key, windowId);
+            }
+
+            sendMessage({
+              type: 'query.response',
+              payload: { requestId, data },
+            });
+          } catch (err) {
+            sendMessage({
+              type: 'query.response',
+              payload: {
+                requestId,
+                data: null,
+                error: err instanceof Error ? err.message : 'Query failed',
+              },
+            });
+          }
+          break;
+        }
+
+        case 'query.unsubscribe.request': {
+          const { key } = msg.payload as { key: string };
+          pendingUnsubscribeKeysRef.current.add(
+            buildPendingSubscriptionKey(webViewWindowIdRef.current, key)
+          );
+          subscribedQueryKeysRef.current.delete(key);
+          appService.mediator.unsubscribeQuery(key, webViewWindowIdRef.current);
+          break;
+        }
+
         case 'editor.focus': {
           const { focused } = msg.payload as { focused: boolean };
+          editorFocusedRef.current = focused;
+          if (focused && keyboardHeight > 0) {
+            sendMessage({
+              type: 'keyboard.show',
+              payload: { height: keyboardHeight },
+            });
+          } else if (!focused) {
+            sendMessage({ type: 'keyboard.hide' });
+          }
           onEditorFocusChange?.(focused);
           break;
         }
@@ -323,8 +447,29 @@ export const PageWebView = forwardRef<PageWebViewHandle, PageWebViewProps>(
         }
       }
     },
-    [appService, userId, sendInit, sendMessage, onNavigateNode, onEditorFocusChange]
+    [
+      appService,
+      keyboardHeight,
+      onEditorFocusChange,
+      onNavigateNode,
+      sendInit,
+      sendMessage,
+      userId,
+    ]
   );
+
+  useEffect(() => {
+    return () => {
+      const windowId = webViewWindowIdRef.current;
+      for (const key of subscribedQueryKeysRef.current) {
+        pendingUnsubscribeKeysRef.current.add(
+          buildPendingSubscriptionKey(windowId, key)
+        );
+        appService.mediator.unsubscribeQuery(key, windowId);
+      }
+      subscribedQueryKeysRef.current.clear();
+    };
+  }, [appService]);
 
   const sendFlush = useCallback(() => {
     if (!isReadyRef.current) return;
@@ -342,7 +487,7 @@ export const PageWebView = forwardRef<PageWebViewHandle, PageWebViewProps>(
     [sendFlush, sendMessage]
   );
 
-  if (!editorHtml) {
+  if (!editorAsset) {
     return (
       <View style={[styles.container, styles.loading, { backgroundColor: colors.background }]}>
         <ActivityIndicator color={colors.textMuted} />
@@ -358,35 +503,62 @@ export const PageWebView = forwardRef<PageWebViewHandle, PageWebViewProps>(
         </View>
       )}
       <WebView
+        key={`${mode}:${nodeId}`}
         ref={webViewRef}
-        source={{ html: editorHtml, baseUrl: '' }}
+        source={{ html: editorAsset.html, baseUrl: editorAsset.baseUrl }}
         injectedJavaScriptBeforeContentLoaded={`
-          if (!crypto.randomUUID) {
-            crypto.randomUUID = function() {
-              var d = new Uint8Array(16);
-              crypto.getRandomValues(d);
-              d[6] = (d[6] & 0x0f) | 0x40;
-              d[8] = (d[8] & 0x3f) | 0x80;
-              var h = '';
-              for (var i = 0; i < 16; i++) {
-                h += d[i].toString(16).padStart(2, '0');
-                if (i === 3 || i === 5 || i === 7 || i === 9) h += '-';
+          (function() {
+            if (typeof window.crypto === 'undefined') {
+              window.crypto = {};
+            }
+            if (typeof window.crypto.getRandomValues !== 'function') {
+              window.crypto.getRandomValues = function(arr) {
+                for (var i = 0; i < arr.length; i++) {
+                  arr[i] = Math.floor(Math.random() * 256);
+                }
+                return arr;
+              };
+            }
+            if (typeof window.crypto.randomUUID !== 'function') {
+              window.crypto.randomUUID = function() {
+                var d = new Uint8Array(16);
+                window.crypto.getRandomValues(d);
+                d[6] = (d[6] & 0x0f) | 0x40;
+                d[8] = (d[8] & 0x3f) | 0x80;
+                var h = '';
+                for (var i = 0; i < 16; i++) {
+                  h += d[i].toString(16).padStart(2, '0');
+                  if (i === 3 || i === 5 || i === 7 || i === 9) h += '-';
+                }
+                return h;
+              };
+            }
+          })();
+          window.__colanodeBridgeReportError = function(prefix, value) {
+            var message = prefix;
+            if (value) {
+              if (value.stack) {
+                message += ': ' + value.stack;
+              } else if (value.message) {
+                message += ': ' + value.message;
+              } else {
+                message += ': ' + String(value);
               }
-              return h;
-            };
-          }
-          window.onerror = function(msg, url, line, col, err) {
+            }
             window.ReactNativeWebView && window.ReactNativeWebView.postMessage(JSON.stringify({
               type: 'error',
-              payload: { message: 'JS Error: ' + msg + ' at ' + url + ':' + line + ':' + col }
+              payload: { message: message }
             }));
           };
-          window.addEventListener('unhandledrejection', function(e) {
-            window.ReactNativeWebView && window.ReactNativeWebView.postMessage(JSON.stringify({
-              type: 'error',
-              payload: { message: 'Unhandled rejection: ' + (e.reason && e.reason.message || e.reason || 'unknown') }
-            }));
+          window.addEventListener('error', function(event) {
+            window.__colanodeBridgeReportError('JS Error', event.error || (event.message + ' at ' + event.filename + ':' + event.lineno + ':' + event.colno));
           });
+          window.addEventListener('unhandledrejection', function(e) {
+            window.__colanodeBridgeReportError('Unhandled rejection', e.reason);
+          });
+          window.onerror = function(msg, url, line, col, err) {
+            window.__colanodeBridgeReportError('JS Error', err || (msg + ' at ' + url + ':' + line + ':' + col));
+          };
 
           true;
         `}

--- a/apps/mobile/src/lib/navigation-utils.ts
+++ b/apps/mobile/src/lib/navigation-utils.ts
@@ -4,31 +4,51 @@ import { LocalNode } from '@colanode/client/types/nodes';
 
 type AppRouter = ReturnType<typeof useRouter>;
 
-export const navigateToNode = (router: AppRouter, node: LocalNode) => {
-  switch (node.type) {
+export const navigateToNodeByType = (
+  router: AppRouter,
+  nodeId: string,
+  nodeType: LocalNode['type']
+) => {
+  switch (nodeType) {
     case 'channel':
       router.push({
         pathname: '/(app)/(spaces)/channel/[channelId]',
-        params: { channelId: node.id },
+        params: { channelId: nodeId },
       });
       break;
     case 'page':
       router.push({
         pathname: '/(app)/(spaces)/page/[pageId]',
-        params: { pageId: node.id },
+        params: { pageId: nodeId },
       });
       break;
     case 'folder':
       router.push({
         pathname: '/(app)/(spaces)/folder/[folderId]',
-        params: { folderId: node.id },
+        params: { folderId: nodeId },
       });
       break;
     case 'file':
       router.push({
         pathname: '/(app)/(spaces)/file/[fileId]',
-        params: { fileId: node.id },
+        params: { fileId: nodeId },
+      });
+      break;
+    case 'database':
+      router.push({
+        pathname: '/(app)/(spaces)/database/[databaseId]',
+        params: { databaseId: nodeId },
+      });
+      break;
+    case 'record':
+      router.push({
+        pathname: '/(app)/(spaces)/record/[recordId]',
+        params: { recordId: nodeId },
       });
       break;
   }
+};
+
+export const navigateToNode = (router: AppRouter, node: LocalNode) => {
+  navigateToNodeByType(router, node.id, node.type);
 };

--- a/apps/mobile/webviews/editor/editor.html
+++ b/apps/mobile/webviews/editor/editor.html
@@ -74,6 +74,57 @@
     <div id="scroll-container">
       <div id="editor-root"></div>
     </div>
+    <script>
+      (function () {
+        function stringifyError(error) {
+          if (!error) {
+            return 'Unknown error';
+          }
+
+          if (error.stack) {
+            return String(error.stack);
+          }
+
+          if (error.message) {
+            return String(error.message);
+          }
+
+          return String(error);
+        }
+
+        function report(message) {
+          try {
+            const rn = window.ReactNativeWebView;
+            if (rn && typeof rn.postMessage === 'function') {
+              rn.postMessage(
+                JSON.stringify({
+                  type: 'error',
+                  payload: { message },
+                })
+              );
+            }
+          } catch {
+            // Ignore reporting failures inside the reporter itself.
+          }
+        }
+
+        window.__colanodeReportFatal = report;
+
+        window.addEventListener('error', function (event) {
+          const location = [event.filename, event.lineno, event.colno]
+            .filter(Boolean)
+            .join(':');
+          const message = event.error
+            ? stringifyError(event.error)
+            : [event.message, location].filter(Boolean).join(' at ');
+          report('Window error: ' + message);
+        });
+
+        window.addEventListener('unhandledrejection', function (event) {
+          report('Unhandled rejection: ' + stringifyError(event.reason));
+        });
+      })();
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/mobile/webviews/editor/src/bridge.ts
+++ b/apps/mobile/webviews/editor/src/bridge.ts
@@ -1,6 +1,8 @@
 import { EventBusService } from '@colanode/client/lib';
 import type { MutationInput, MutationResult } from '@colanode/client/mutations';
 import type { QueryInput, QueryMap } from '@colanode/client/queries';
+import type { Event } from '@colanode/client/types';
+import type { WorkspaceRole } from '@colanode/core';
 import type { ColanodeWindowApi } from '@colanode/ui/window';
 
 // Types for messages between WebView and Native
@@ -8,10 +10,12 @@ export type NativeToWebViewMessage =
   | {
       type: 'init';
       payload: {
+        mode: 'page' | 'database' | 'record';
         nodeId: string;
         userId: string;
         accountId: string;
         workspaceId: string;
+        workspaceRole: WorkspaceRole;
         rootId: string;
         canEdit: boolean;
         theme: 'light' | 'dark';
@@ -38,7 +42,8 @@ export type NativeToWebViewMessage =
   | { type: 'keyboard.show'; payload: { height: number } }
   | { type: 'keyboard.hide' }
   | { type: 'editor.blur' }
-  | { type: 'block.command'; payload: { command: string } };
+  | { type: 'block.command'; payload: { command: string } }
+  | { type: 'event.publish'; payload: { event: Event } };
 
 export type WebViewToNativeMessage =
   | { type: 'ready' }
@@ -49,6 +54,14 @@ export type WebViewToNativeMessage =
   | {
       type: 'query.request';
       payload: { requestId: string; input: QueryInput };
+    }
+  | {
+      type: 'query.subscribe.request';
+      payload: { requestId: string; key: string; input: QueryInput };
+    }
+  | {
+      type: 'query.unsubscribe.request';
+      payload: { key: string };
     }
   | {
       type: 'navigate.node';
@@ -91,20 +104,34 @@ function generateRequestId(): string {
 }
 
 function sendRequest(
-  type: 'mutation.request' | 'query.request',
-  input: unknown
+  message:
+    | {
+        type: 'mutation.request';
+        payload: { input: MutationInput };
+      }
+    | {
+        type: 'query.request';
+        payload: { input: QueryInput };
+      }
+    | {
+        type: 'query.subscribe.request';
+        payload: { key: string; input: QueryInput };
+      }
 ): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const requestId = generateRequestId();
     const timer = setTimeout(() => {
       pendingRequests.delete(requestId);
-      reject(new Error(`Bridge request timed out: ${type}`));
+      reject(new Error(`Bridge request timed out: ${message.type}`));
     }, REQUEST_TIMEOUT);
 
     pendingRequests.set(requestId, { resolve, reject, timer });
     postToNative({
-      type,
-      payload: { requestId, input: input as MutationInput & QueryInput },
+      ...message,
+      payload: {
+        ...message.payload,
+        requestId,
+      },
     } as WebViewToNativeMessage);
   });
 }
@@ -120,27 +147,38 @@ function handleNativeMessage(event: MessageEvent) {
 
   if (!msg || !msg.type) return;
 
-  // Handle request responses
-  if (msg.type === 'mutation.response' || msg.type === 'query.response') {
-    const { requestId, error } = msg.payload;
-    const pending = pendingRequests.get(requestId);
-    if (pending) {
-      clearTimeout(pending.timer);
-      pendingRequests.delete(requestId);
-      if (error) {
-        pending.reject(new Error(error));
-      } else {
-        const data =
-          msg.type === 'mutation.response' ? msg.payload.result : msg.payload.data;
-        pending.resolve(data);
+  try {
+    // Handle request responses
+    if (msg.type === 'mutation.response' || msg.type === 'query.response') {
+      const { requestId, error } = msg.payload;
+      const pending = pendingRequests.get(requestId);
+      if (pending) {
+        clearTimeout(pending.timer);
+        pendingRequests.delete(requestId);
+        if (error) {
+          pending.reject(new Error(error));
+        } else {
+          const data =
+            msg.type === 'mutation.response' ? msg.payload.result : msg.payload.data;
+          pending.resolve(data);
+        }
       }
+      return;
     }
-    return;
-  }
 
-  // Forward all other messages to listeners
-  for (const listener of messageListeners) {
-    listener(msg);
+    if (msg.type === 'event.publish') {
+      window.eventBus.publish(msg.payload.event);
+      return;
+    }
+
+    // Forward all other messages to listeners
+    for (const listener of messageListeners) {
+      listener(msg);
+    }
+  } catch (err) {
+    postError(
+      `Bridge message handler error (${msg.type}): ${err instanceof Error ? err.stack ?? err.message : String(err)}`
+    );
   }
 }
 
@@ -158,26 +196,40 @@ const bridgeApi: ColanodeWindowApi = {
   executeMutation: async <T extends MutationInput>(
     input: T
   ): Promise<MutationResult<T>> => {
-    const result = await sendRequest('mutation.request', input);
+    const result = await sendRequest({
+      type: 'mutation.request',
+      payload: { input },
+    });
     return result as MutationResult<T>;
   },
 
   executeQuery: async <T extends QueryInput>(
     input: T
   ): Promise<QueryMap[T['type']]['output']> => {
-    const result = await sendRequest('query.request', input);
+    const result = await sendRequest({
+      type: 'query.request',
+      payload: { input },
+    });
     return result as QueryMap[T['type']]['output'];
   },
 
   executeQueryAndSubscribe: async <T extends QueryInput>(
-    _key: string,
+    key: string,
     input: T
   ): Promise<QueryMap[T['type']]['output']> => {
-    const result = await sendRequest('query.request', input);
+    const result = await sendRequest({
+      type: 'query.subscribe.request',
+      payload: { key, input },
+    });
     return result as QueryMap[T['type']]['output'];
   },
 
-  unsubscribeQuery: async () => {},
+  unsubscribeQuery: async (key: string) => {
+    postToNative({
+      type: 'query.unsubscribe.request',
+      payload: { key },
+    });
+  },
 
   saveTempFile: async () => {
     throw new Error('saveTempFile is not supported in mobile editor');

--- a/apps/mobile/webviews/editor/src/database-runtime.tsx
+++ b/apps/mobile/webviews/editor/src/database-runtime.tsx
@@ -1,0 +1,733 @@
+import { eq, useLiveQuery } from '@tanstack/react-db';
+import { InView } from 'react-intersection-observer';
+import {
+  Fullscreen,
+  Lock,
+  LockOpen,
+  SquareArrowOutUpRight,
+  Trash2,
+} from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+import {
+  LocalDatabaseNode,
+  LocalDatabaseViewNode,
+  LocalRecordNode,
+  ViewField,
+} from '@colanode/client/types';
+import {
+  compareString,
+  DatabaseViewFilterAttributes,
+  DatabaseViewSortAttributes,
+  IdType,
+  SpecialId,
+  SortDirection,
+  extractNodeRole,
+  generateId,
+} from '@colanode/core';
+import { DatabaseNotFound } from '@colanode/ui/components/databases/database-not-found';
+import { Database } from '@colanode/ui/components/databases/database';
+import { ViewAvatarInput } from '@colanode/ui/components/databases/view-avatar-input';
+import { ViewFieldSettings } from '@colanode/ui/components/databases/view-field-settings';
+import { ViewRenameInput } from '@colanode/ui/components/databases/view-rename-input';
+import { ViewSettingsButton } from '@colanode/ui/components/databases/view-settings-button';
+import { ViewTab } from '@colanode/ui/components/databases/view-tab';
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@colanode/ui/components/ui/alert-dialog';
+import { Button } from '@colanode/ui/components/ui/button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@colanode/ui/components/ui/popover';
+import { Separator } from '@colanode/ui/components/ui/separator';
+import { DatabaseViewsContext } from '@colanode/ui/contexts/database-views';
+import { DatabaseViewContext } from '@colanode/ui/contexts/database-view';
+import { useDatabase } from '@colanode/ui/contexts/database';
+import { useDatabaseView } from '@colanode/ui/contexts/database-view';
+import { useDatabaseViews } from '@colanode/ui/contexts/database-views';
+import { useNode } from '@colanode/ui/contexts/node';
+import { useWorkspace } from '@colanode/ui/contexts/workspace';
+import { TableViewEmptyPlaceholder } from '@colanode/ui/components/databases/tables/table-view-empty-placeholder';
+import { TableViewRecordCreateRow } from '@colanode/ui/components/databases/tables/table-view-record-create-row';
+import { ViewFilterButton } from '@colanode/ui/components/databases/search/view-filter-button';
+import { ViewSearchBar } from '@colanode/ui/components/databases/search/view-search-bar';
+import { ViewSortButton } from '@colanode/ui/components/databases/search/view-sort-button';
+import { NodeProvider } from '@colanode/ui/components/nodes/node-provider';
+import { RecordFieldValue } from '@colanode/ui/components/records/record-field-value';
+import { RecordProvider } from '@colanode/ui/components/records/record-provider';
+import { useRecord } from '@colanode/ui/contexts/record';
+import { useMetadata } from '@colanode/ui/hooks/use-metadata';
+import { useRecordsQuery } from '@colanode/ui/hooks/use-records-query';
+import {
+  generateFieldValuesFromFilters,
+  getDefaultFieldWidth,
+  getDefaultNameWidth,
+  getDefaultViewFieldDisplay,
+} from '@colanode/ui/lib/databases';
+
+import { postNavigateNode } from './bridge';
+
+interface MobileDatabaseRuntimeProps {
+  databaseId: string;
+  inline?: boolean;
+}
+
+interface MobileDatabaseViewsProps {
+  inline?: boolean;
+}
+
+interface MobileDatabaseViewProps {
+  view: LocalDatabaseViewNode;
+  inline?: boolean;
+}
+
+export const MobileDatabaseRuntime = ({
+  databaseId,
+  inline = false,
+}: MobileDatabaseRuntimeProps) => {
+  return (
+    <NodeProvider nodeId={databaseId}>
+      <MobileDatabaseRuntimeContent inline={inline} />
+    </NodeProvider>
+  );
+};
+
+const MobileDatabaseRuntimeContent = ({
+  inline,
+}: {
+  inline: boolean;
+}) => {
+  const { node, role } = useNode<LocalDatabaseNode>();
+
+  if (!node || node.type !== 'database') {
+    return <DatabaseNotFound />;
+  }
+
+  return (
+    <Database database={node} role={role}>
+      <MobileDatabaseViews inline={inline} />
+    </Database>
+  );
+};
+
+const MobileDatabaseViews = ({
+  inline = false,
+}: MobileDatabaseViewsProps) => {
+  const workspace = useWorkspace();
+  const database = useDatabase();
+
+  const [activeViewId, setActiveViewId] = useMetadata<string>(
+    workspace.userId,
+    `${database.id}.activeViewId`
+  );
+
+  const viewsQuery = useLiveQuery(
+    (q) =>
+      q
+        .from({ nodes: workspace.collections.nodes })
+        .where(({ nodes }) => eq(nodes.type, 'database_view'))
+        .where(({ nodes }) => eq(nodes.parentId, database.id)),
+    [workspace.userId, database.id]
+  );
+
+  const views = (viewsQuery.data ?? [])
+    .map((node) => node as LocalDatabaseViewNode)
+    .sort((a, b) => compareString(a.index, b.index));
+
+  const activeView = views.find((view) => view.id === activeViewId) ?? views[0];
+
+  if (!activeView) {
+    return null;
+  }
+
+  return (
+    <DatabaseViewsContext.Provider
+      value={{
+        views,
+        activeViewId: activeView.id,
+        onActiveViewChange: setActiveViewId,
+        inline,
+      }}
+    >
+      <MobileDatabaseView view={activeView} inline={inline} />
+    </DatabaseViewsContext.Provider>
+  );
+};
+
+const MobileDatabaseView = ({
+  view,
+  inline = false,
+}: MobileDatabaseViewProps) => {
+  const workspace = useWorkspace();
+  const database = useDatabase();
+
+  const fields: ViewField[] = database.fields
+    .map((field) => {
+      const viewField = view.fields?.[field.id];
+
+      return {
+        field,
+        display: viewField?.display ?? getDefaultViewFieldDisplay(view.layout),
+        index: viewField?.index ?? field.index,
+        width: viewField?.width ?? getDefaultFieldWidth(field.type),
+      };
+    })
+    .filter((field) => field.display)
+    .sort((a, b) => compareString(a.index, b.index));
+
+  const [isSearchBarOpened, setIsSearchBarOpened] = useState(false);
+  const [isSortsOpened, setIsSortsOpened] = useState(false);
+  const [openedFieldFilters, setOpenedFieldFilters] = useState<string[]>([]);
+
+  return (
+    <DatabaseViewContext.Provider
+      value={{
+        id: view.id,
+        name: view.name,
+        avatar: view.avatar,
+        layout: view.layout,
+        fields,
+        filters: Object.values(view.filters ?? {}),
+        sorts: Object.values(view.sorts ?? {}),
+        groupBy: view.groupBy,
+        nameWidth: view.nameWidth ?? getDefaultNameWidth(),
+        isSearchBarOpened: isSearchBarOpened || openedFieldFilters.length > 0,
+        isSortsOpened,
+        isFieldFilterOpened: (fieldId: string) =>
+          openedFieldFilters.includes(fieldId),
+        initFieldFilter: (fieldId: string) => {
+          workspace.collections.nodes.update(view.id, (draft) => {
+            if (draft.type !== 'database_view') return;
+
+            const existingFilter = draft.filters?.[fieldId];
+            if (existingFilter) {
+              setOpenedFieldFilters((prev) =>
+                prev.filter((id) => id !== fieldId)
+              );
+              return;
+            }
+
+            if (
+              fieldId !== SpecialId.Name &&
+              !database.fields.find((field) => field.id === fieldId)
+            ) {
+              return;
+            }
+
+            const filter: DatabaseViewFilterAttributes = {
+              id: fieldId,
+              fieldId,
+              type: 'field',
+              operator: 'equals',
+              value: '',
+            };
+
+            draft.filters = {
+              ...draft.filters,
+              [fieldId]: filter,
+            };
+
+            setOpenedFieldFilters((prev) => [...prev, fieldId]);
+          });
+        },
+        initFieldSort: (fieldId: string, direction: SortDirection) => {
+          if (!database.canEdit || database.isLocked) {
+            return;
+          }
+
+          workspace.collections.nodes.update(view.id, (draft) => {
+            if (draft.type !== 'database_view') return;
+
+            const existingSort = draft.sorts?.[fieldId];
+            if (existingSort && existingSort.direction === direction) {
+              return;
+            }
+
+            if (
+              fieldId !== SpecialId.Name &&
+              !database.fields.find((field) => field.id === fieldId)
+            ) {
+              return;
+            }
+
+            const sort: DatabaseViewSortAttributes = {
+              id: fieldId,
+              fieldId,
+              direction,
+            };
+
+            draft.sorts = {
+              ...draft.sorts,
+              [fieldId]: sort,
+            };
+          });
+        },
+        openSearchBar: () => setIsSearchBarOpened(true),
+        closeSearchBar: () => setIsSearchBarOpened(false),
+        openSorts: () => setIsSortsOpened(true),
+        closeSorts: () => setIsSortsOpened(false),
+        openFieldFilter: (fieldId: string) => {
+          setOpenedFieldFilters((prev) => [...prev, fieldId]);
+        },
+        closeFieldFilter: (fieldId: string) => {
+          setOpenedFieldFilters((prev) => prev.filter((id) => id !== fieldId));
+        },
+        createRecord: (filters?: DatabaseViewFilterAttributes[]) => {
+          if (!database.canCreateRecord || database.isLocked) {
+            return;
+          }
+
+          const allFilters = [
+            ...(Object.values(view.filters ?? {}) ?? []),
+            ...(filters ?? []),
+          ];
+
+          const recordId = generateId(IdType.Record);
+          const record: LocalRecordNode = {
+            id: recordId,
+            type: 'record',
+            parentId: database.id,
+            rootId: database.rootId,
+            databaseId: database.id,
+            name: '',
+            fields: generateFieldValuesFromFilters(
+              database.fields,
+              allFilters,
+              workspace.userId
+            ),
+            createdAt: new Date().toISOString(),
+            createdBy: workspace.userId,
+            updatedAt: null,
+            updatedBy: null,
+            localRevision: '0',
+            serverRevision: '0',
+          };
+
+          workspace.collections.nodes.insert(record);
+          postNavigateNode(record.id, 'record');
+        },
+      }}
+    >
+      {view.layout === 'table' ? (
+        <MobileTableView inline={inline} />
+      ) : (
+        <MobileUnsupportedView inline={inline} />
+      )}
+    </DatabaseViewContext.Provider>
+  );
+};
+
+const MobileInlineFullscreenButton = () => {
+  const database = useDatabase();
+  const views = useDatabaseViews();
+
+  if (!views.inline) {
+    return null;
+  }
+
+  return (
+    <button
+      type="button"
+      className="flex cursor-pointer items-center rounded-md p-1.5 hover:bg-accent"
+      onClick={() => postNavigateNode(database.id, 'database')}
+    >
+      <Fullscreen className="size-4" />
+    </button>
+  );
+};
+
+const MobileViewTabs = () => {
+  const databaseViews = useDatabaseViews();
+
+  return (
+    <div className="flex flex-row items-center gap-3 overflow-x-auto pr-2">
+      {databaseViews.views.map((view) => (
+        <ViewTab
+          key={view.id}
+          view={view}
+          isActive={view.id === databaseViews.activeViewId}
+          onClick={() => databaseViews.onActiveViewChange(view.id)}
+        />
+      ))}
+    </div>
+  );
+};
+
+const MobileViewSettings = () => {
+  const workspace = useWorkspace();
+  const database = useDatabase();
+  const view = useDatabaseView();
+  const databaseViews = useDatabaseViews();
+
+  const [open, setOpen] = useState(false);
+  const [openDelete, setOpenDelete] = useState(false);
+
+  const canDeleteView = databaseViews.views.length > 1;
+
+  const handleDeleteView = () => {
+    const nextViewId =
+      databaseViews.views.find((candidate) => candidate.id !== view.id)?.id ??
+      '';
+
+    workspace.collections.nodes.delete(view.id);
+    databaseViews.onActiveViewChange(nextViewId);
+    setOpenDelete(false);
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger>
+          <ViewSettingsButton />
+        </PopoverTrigger>
+        <PopoverContent className="mr-4 flex w-90 flex-col gap-1.5 p-2">
+          <div className="flex flex-row items-center gap-2">
+            <ViewAvatarInput
+              id={view.id}
+              name={view.name}
+              avatar={view.avatar}
+              layout={view.layout}
+              readOnly={!database.canEdit || database.isLocked}
+            />
+            <ViewRenameInput
+              id={view.id}
+              name={view.name}
+              readOnly={!database.canEdit || database.isLocked}
+            />
+          </div>
+          <Separator />
+          <ViewFieldSettings />
+          {database.canEdit && (
+            <>
+              <Separator />
+              <div className="flex flex-col gap-2 text-sm">
+                <p className="my-1 font-semibold">Settings</p>
+                <div
+                  className="flex cursor-pointer flex-row items-center gap-1 rounded-md p-0.5 hover:bg-accent"
+                  onClick={() => {
+                    database.toggleLock();
+                  }}
+                >
+                  {database.isLocked ? (
+                    <LockOpen className="size-4" />
+                  ) : (
+                    <Lock className="size-4" />
+                  )}
+                  <span>
+                    {database.isLocked ? 'Unlock database' : 'Lock database'}
+                  </span>
+                </div>
+                {canDeleteView && !database.isLocked && (
+                  <div
+                    className="flex cursor-pointer flex-row items-center gap-1 rounded-md p-0.5 hover:bg-accent"
+                    onClick={() => {
+                      setOpenDelete(true);
+                      setOpen(false);
+                    }}
+                  >
+                    <Trash2 className="size-4" />
+                    <span>Delete view</span>
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+        </PopoverContent>
+      </Popover>
+      <AlertDialog open={openDelete} onOpenChange={setOpenDelete}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Are you sure you want delete this view?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone. This view will no longer be
+              accessible and all data in the view will be lost.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <Button variant="destructive" onClick={handleDeleteView}>
+              Delete
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+};
+
+const MobileTableView = ({ inline }: { inline: boolean }) => {
+  return (
+    <div className="w-full h-full group/database">
+      <div className="flex flex-row justify-between border-b gap-2">
+        <MobileViewTabs />
+        <div className="flex flex-row items-center justify-end gap-1">
+          {inline && <MobileInlineFullscreenButton />}
+          <MobileViewSettings />
+          <ViewSortButton />
+          <ViewFilterButton />
+        </div>
+      </div>
+      <ViewSearchBar />
+      <div className="mt-2 w-full min-w-full max-w-full overflow-auto pr-1">
+        <MobileTableViewHeader />
+        <MobileTableViewBody />
+        <MobileTableViewRecordCreateRow />
+      </div>
+    </div>
+  );
+};
+
+const MobileTableViewHeader = () => {
+  const database = useDatabase();
+  const view = useDatabaseView();
+
+  return (
+    <div className="flex flex-row items-center gap-0.5 border-b bg-background">
+      <div
+        className="flex h-8 items-center justify-center text-xs text-muted-foreground"
+        style={{ width: '30px', minWidth: '30px' }}
+      >
+        #
+      </div>
+      <div
+        className="flex h-8 items-center border-r px-2 text-sm font-medium"
+        style={{ width: `${view.nameWidth}px`, minWidth: '240px' }}
+      >
+        <span className="truncate">{database.nameField?.name ?? 'Name'}</span>
+      </div>
+      {view.fields.map((field) => (
+        <div
+          key={`header-${field.field.id}`}
+          className="flex h-8 items-center border-r px-2 text-sm font-medium"
+          style={{ width: `${field.width}px`, minWidth: '120px' }}
+        >
+          <span className="truncate">{field.field.name}</span>
+        </div>
+      ))}
+      <div className="w-2" />
+    </div>
+  );
+};
+
+const MobileUnsupportedView = ({ inline }: { inline: boolean }) => {
+  const view = useDatabaseView();
+  const databaseViews = useDatabaseViews();
+  const tableView = databaseViews.views.find(
+    (candidate) => candidate.layout === 'table'
+  );
+  const layoutName =
+    view.layout === 'board'
+      ? 'Board'
+      : view.layout === 'calendar'
+        ? 'Calendar'
+        : 'This';
+
+  return (
+    <div className="w-full h-full group/database">
+      <div className="flex flex-row justify-between border-b gap-2">
+        <MobileViewTabs />
+        <div className="flex flex-row items-center justify-end gap-1">
+          {inline && <MobileInlineFullscreenButton />}
+          <MobileViewSettings />
+        </div>
+      </div>
+      <div className="flex min-h-[280px] flex-col items-center justify-center gap-3 px-4 py-8 text-center">
+        <div className="max-w-sm space-y-2">
+          <p className="text-base font-medium">
+            {layoutName} views are not available on mobile yet.
+          </p>
+          <p className="text-sm text-muted-foreground">
+            Open a table view to browse and edit records on mobile.
+          </p>
+        </div>
+        {tableView ? (
+          <button
+            type="button"
+            className="rounded-md border px-3 py-2 text-sm hover:bg-accent"
+            onClick={() => databaseViews.onActiveViewChange(tableView.id)}
+          >
+            Open {tableView.name || 'Table'} view
+          </button>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            Create a table view on desktop or web to use this database on
+            mobile.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const MobileTableViewBody = () => {
+  const view = useDatabaseView();
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useRecordsQuery(view.filters, view.sorts);
+  const records = data ?? [];
+
+  return (
+    <div className="border-t">
+      {records.length === 0 && <TableViewEmptyPlaceholder />}
+      {records.map((record, index) => (
+        <MobileTableViewRow key={record.id} index={index} record={record} />
+      ))}
+      <InView
+        rootMargin="200px"
+        onChange={(inView) => {
+          if (inView && hasNextPage && !isFetchingNextPage) {
+            fetchNextPage();
+          }
+        }}
+      />
+    </div>
+  );
+};
+
+const MobileTableViewRow = ({
+  index,
+  record,
+}: {
+  index: number;
+  record: LocalRecordNode;
+}) => {
+  const workspace = useWorkspace();
+  const database = useDatabase();
+  const view = useDatabaseView();
+  const role = extractNodeRole(record, workspace.userId) ?? database.role;
+
+  return (
+    <RecordProvider record={record} role={role}>
+      <div className="animate-fade-in flex flex-row items-center gap-0.5 border-b">
+        <span
+          className="flex items-center justify-center text-sm text-muted-foreground"
+          style={{ width: '30px', minWidth: '30px' }}
+        >
+          {index + 1}
+        </span>
+        <div
+          className="h-8 border-r overflow-hidden"
+          style={{ width: `${view.nameWidth}px`, minWidth: '240px' }}
+        >
+          <MobileTableViewNameCell record={record} />
+        </div>
+        {view.fields.map((field) => (
+          <div
+            key={`row-${record.id}-${field.field.id}`}
+            className="h-8 border-r p-1 overflow-hidden"
+            style={{ width: `${field.width}px`, minWidth: '120px' }}
+          >
+            <RecordFieldValue field={field.field} readOnly={database.isLocked} />
+          </div>
+        ))}
+        <div className="w-2" />
+      </div>
+    </RecordProvider>
+  );
+};
+
+const MobileTableViewRecordCreateRow = () => {
+  const database = useDatabase();
+
+  if (!database.canCreateRecord || database.isLocked) {
+    return null;
+  }
+
+  return <TableViewRecordCreateRow />;
+};
+
+const MobileTableViewNameCell = ({ record }: { record: LocalRecordNode }) => {
+  const workspace = useWorkspace();
+  const database = useDatabase();
+  const currentRecord = useRecord();
+  const [isEditing, setIsEditing] = useState(false);
+  const [value, setValue] = useState(record.name ?? '');
+  const canEditName = currentRecord.canEdit && !database.isLocked;
+
+  useEffect(() => {
+    if (!isEditing) {
+      setValue(record.name ?? '');
+    }
+  }, [isEditing, record.name]);
+
+  const save = () => {
+    if (!canEditName) {
+      setIsEditing(false);
+      return;
+    }
+
+    if (value !== record.name) {
+      workspace.collections.nodes.update(record.id, (draft) => {
+        if (draft.type !== 'record') {
+          return;
+        }
+
+        draft.name = value;
+      });
+    }
+
+    setIsEditing(false);
+  };
+
+  return (
+    <div className="group relative flex h-full w-full items-center">
+      {isEditing ? (
+        <input
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          onBlur={save}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              event.preventDefault();
+              save();
+            }
+            if (event.key === 'Escape') {
+              event.preventDefault();
+              setValue(record.name ?? '');
+              setIsEditing(false);
+            }
+          }}
+          className="flex h-full w-full cursor-text flex-row items-center gap-1 p-1 text-sm outline-none"
+          autoFocus
+        />
+      ) : (
+        <>
+          <button
+            type="button"
+            onClick={() => {
+              if (!canEditName) {
+                return;
+              }
+
+              setIsEditing(true);
+            }}
+            className="flex h-full w-full cursor-pointer flex-row items-center gap-1 p-1 text-sm text-left"
+          >
+            {record.name ? (
+              <span className="truncate">{record.name}</span>
+            ) : (
+              <span className="text-muted-foreground">Unnamed</span>
+            )}
+          </button>
+          <button
+            type="button"
+            className="absolute right-2 flex h-6 cursor-pointer flex-row items-center gap-1 rounded-md border p-1 text-sm text-muted-foreground hover:bg-accent"
+            onClick={() => postNavigateNode(record.id, 'record')}
+          >
+            <SquareArrowOutUpRight className="size-4" />
+          </button>
+        </>
+      )}
+    </div>
+  );
+};

--- a/apps/mobile/webviews/editor/src/document-editor.tsx
+++ b/apps/mobile/webviews/editor/src/document-editor.tsx
@@ -67,6 +67,8 @@ import {
   BlockquoteCommand,
   BulletListCommand,
   CodeBlockCommand,
+  DatabaseCommand,
+  DatabaseInlineCommand,
   DividerCommand,
   Heading1Command,
   Heading2Command,
@@ -263,6 +265,8 @@ export const DocumentEditor = ({
             Heading1Command,
             Heading2Command,
             Heading3Command,
+            DatabaseInlineCommand,
+            DatabaseCommand,
             BulletListCommand,
             CodeBlockCommand,
             OrderedListCommand,
@@ -349,17 +353,25 @@ export const DocumentEditor = ({
     reconcileRef.current(editor, state, updates, node.id);
   }, [state, updates, editor, node.id]);
 
-  // Expose flush for the bridge so pending saves are not lost
+  // Register flush callback so pending saves are not lost on navigation/background
   useEffect(() => {
-    (window as unknown as { __editorFlush?: () => void }).__editorFlush =
-      () => {
-        if (hasPendingChanges.current && editor) {
-          debouncedSave.flush();
-        }
-      };
+    type FlushWindow = Window & typeof globalThis & {
+      __flushCallbacks?: Array<() => void>;
+    };
+    const win = window as FlushWindow;
+    if (!win.__flushCallbacks) {
+      win.__flushCallbacks = [];
+    }
+    const flushCb = () => {
+      if (hasPendingChanges.current && editor) {
+        debouncedSave.flush();
+      }
+    };
+    win.__flushCallbacks.push(flushCb);
     return () => {
-      delete (window as unknown as { __editorFlush?: () => void })
-        .__editorFlush;
+      win.__flushCallbacks = win.__flushCallbacks?.filter(
+        (cb) => cb !== flushCb
+      );
     };
   }, [debouncedSave, editor]);
 

--- a/apps/mobile/webviews/editor/src/editor.tsx
+++ b/apps/mobile/webviews/editor/src/editor.tsx
@@ -1,22 +1,63 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { Component, useCallback, useEffect, useRef, useState } from 'react';
+import type { ErrorInfo, ReactNode } from 'react';
 
 import type { DocumentState, DocumentUpdate } from '@colanode/client/types';
 import type { LocalNode } from '@colanode/client/types/nodes';
-import type { WorkspaceRole } from '@colanode/core';
+import { WorkspaceStatus, type WorkspaceRole } from '@colanode/core';
+import { AppContext } from '@colanode/ui/contexts/app';
+import { collections } from '@colanode/ui/collections';
 import { WorkspaceContext } from '@colanode/ui/contexts/workspace';
+import { buildQueryClient } from '@colanode/ui/lib/query';
+import { DatabaseCommand, DatabaseInlineCommand } from '@colanode/ui/editor/commands';
 
+import { MobileDatabaseRuntime } from './database-runtime';
 import { DocumentEditor } from './document-editor';
 import {
   onNativeMessage,
+  postEditorFocus,
+  postError,
   postReady,
   type NativeToWebViewMessage,
 } from './bridge';
+import { MobileRecordRuntime } from './record-runtime';
+
+class EditorErrorBoundary extends Component<
+  { children: ReactNode },
+  { error: Error | null }
+> {
+  state: { error: Error | null } = { error: null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    const details = `React error: ${error.stack ?? error.message}${info.componentStack ? `\nComponent stack: ${info.componentStack}` : ''}`;
+    postError(details);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div style={{ padding: 16, color: 'red', fontSize: 12 }}>
+          <p>
+            <strong>Editor error:</strong> {this.state.error.message}
+          </p>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
 
 interface InitPayload {
+  mode: 'page' | 'database' | 'record';
   nodeId: string;
   userId: string;
   accountId: string;
   workspaceId: string;
+  workspaceRole: WorkspaceRole;
   rootId: string;
   canEdit: boolean;
   theme: 'light' | 'dark';
@@ -26,10 +67,12 @@ interface InitPayload {
 }
 
 interface EditorState {
+  mode: 'page' | 'database' | 'record';
   nodeId: string;
   userId: string;
   accountId: string;
   workspaceId: string;
+  workspaceRole: WorkspaceRole;
   rootId: string;
   canEdit: boolean;
   docState: DocumentState | null;
@@ -62,12 +105,30 @@ function buildDocUpdates(
 
 export function MobileEditorApp() {
   const [editorState, setEditorState] = useState<EditorState | null>(null);
+  const [runtimeReady, setRuntimeReady] = useState(false);
   const editorStateRef = useRef<EditorState | null>(null);
+  const preloadPromiseRef = useRef<Promise<void> | null>(null);
+  const queryClientRef = useRef<ReturnType<typeof buildQueryClient> | null>(
+    null
+  );
+
+  if (queryClientRef.current === null) {
+    queryClientRef.current = buildQueryClient();
+  }
+
+  const ensureCollectionsReady = useCallback(async () => {
+    if (!preloadPromiseRef.current) {
+      preloadPromiseRef.current = collections.preload();
+    }
+
+    await preloadPromiseRef.current;
+  }, []);
 
   const handleMessage = useCallback((msg: NativeToWebViewMessage) => {
     switch (msg.type) {
       case 'init': {
         const p = msg.payload as InitPayload;
+        setRuntimeReady(false);
 
         // Set theme
         if (p.theme === 'dark') {
@@ -77,17 +138,36 @@ export function MobileEditorApp() {
         }
 
         const state: EditorState = {
+          mode: p.mode,
           nodeId: p.nodeId,
           userId: p.userId,
           accountId: p.accountId,
           workspaceId: p.workspaceId,
+          workspaceRole: p.workspaceRole,
           rootId: p.rootId,
           canEdit: p.canEdit,
           docState: buildDocState(p.nodeId, p.state),
           docUpdates: buildDocUpdates(p.nodeId, p.updates),
         };
-        editorStateRef.current = state;
-        setEditorState(state);
+        void ensureCollectionsReady().then(() => {
+          if (!collections.workspaces.has(p.userId)) {
+            collections.workspaces.insert({
+              userId: p.userId,
+              workspaceId: p.workspaceId,
+              accountId: p.accountId,
+              role: p.workspaceRole,
+              name: '',
+              description: null,
+              avatar: null,
+              status: WorkspaceStatus.Active,
+              maxFileSize: undefined,
+            });
+          }
+
+          editorStateRef.current = state;
+          setEditorState(state);
+          setRuntimeReady(true);
+        });
         break;
       }
 
@@ -135,11 +215,29 @@ export function MobileEditorApp() {
       }
 
       case 'flush': {
-        // Flush any pending debounced save immediately
-        const flush = (window as unknown as { __editorFlush?: () => void })
-          .__editorFlush;
-        if (flush) {
-          flush();
+        // Flush any pending debounced save immediately.
+        // 1. Call all registered flush callbacks (TipTap editor, etc.)
+        const callbacks = (
+          window as unknown as { __flushCallbacks?: Array<() => void> }
+        ).__flushCallbacks;
+        if (callbacks) {
+          for (const cb of callbacks) {
+            try {
+              cb();
+            } catch {
+              // ignore flush errors
+            }
+          }
+        }
+        // 2. Blur the active element so input-based components (record name,
+        //    field values) commit their pending debounced mutations via their
+        //    own blur/change handlers before the WebView is torn down.
+        if (
+          document.activeElement instanceof HTMLInputElement ||
+          document.activeElement instanceof HTMLTextAreaElement ||
+          document.activeElement instanceof HTMLSelectElement
+        ) {
+          document.activeElement.blur();
         }
         break;
       }
@@ -159,21 +257,42 @@ export function MobileEditorApp() {
               `${kbHeight}px`
             );
 
-            const selection = window.getSelection();
-            if (selection && selection.rangeCount > 0) {
-              const range = selection.getRangeAt(0);
-              const rect = range.getBoundingClientRect();
-              const viewportHeight = window.innerHeight;
-              // The visible area ends where the keyboard begins
-              const visibleBottom = viewportHeight - kbHeight - 60;
-              if (rect.bottom > visibleBottom) {
-                // Scroll so cursor is comfortably above the keyboard
-                const scrollBy = rect.bottom - visibleBottom + 40;
-                container.scrollBy({
-                  top: scrollBy,
-                  behavior: 'smooth',
-                });
+            const activeElement = document.activeElement;
+            let focusBottom: number | null = null;
+
+            if (
+              activeElement instanceof HTMLInputElement ||
+              activeElement instanceof HTMLTextAreaElement ||
+              activeElement instanceof HTMLSelectElement
+            ) {
+              focusBottom = activeElement.getBoundingClientRect().bottom;
+            } else {
+              const selection = window.getSelection();
+              if (selection && selection.rangeCount > 0) {
+                try {
+                  focusBottom = selection
+                    .getRangeAt(0)
+                    .getBoundingClientRect().bottom;
+                } catch {
+                  focusBottom = null;
+                }
               }
+            }
+
+            if (focusBottom == null) {
+              return;
+            }
+
+            const viewportHeight = window.innerHeight;
+            // The visible area ends where the keyboard begins
+            const visibleBottom = viewportHeight - kbHeight - 60;
+            if (focusBottom > visibleBottom) {
+              // Scroll so the focused control stays comfortably above the keyboard
+              const scrollBy = focusBottom - visibleBottom + 40;
+              container.scrollBy({
+                top: scrollBy,
+                behavior: 'smooth',
+              });
             }
           });
         });
@@ -202,6 +321,7 @@ export function MobileEditorApp() {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const ei = (window as any).__editorInstance;
         if (!ei) break;
+        const current = editorStateRef.current;
         try {
           const chain = ei.chain().focus();
           switch (command) {
@@ -238,6 +358,44 @@ export function MobileEditorApp() {
             case 'table':
               chain.insertTable({ rows: 3, cols: 3, withHeaderRow: false }).run();
               break;
+            case 'databaseInline':
+              if (!current) {
+                break;
+              }
+              void DatabaseInlineCommand.handler({
+                editor: ei,
+                range: {
+                  from: ei.state.selection.from,
+                  to: ei.state.selection.to,
+                },
+                context: {
+                  userId: current.userId,
+                  documentId: current.nodeId,
+                  accountId: current.accountId,
+                  workspaceId: current.workspaceId,
+                  rootId: current.rootId,
+                },
+              });
+              break;
+            case 'database':
+              if (!current) {
+                break;
+              }
+              void DatabaseCommand.handler({
+                editor: ei,
+                range: {
+                  from: ei.state.selection.from,
+                  to: ei.state.selection.to,
+                },
+                context: {
+                  userId: current.userId,
+                  documentId: current.nodeId,
+                  accountId: current.accountId,
+                  workspaceId: current.workspaceId,
+                  rootId: current.rootId,
+                },
+              });
+              break;
           }
         } catch (e) {
           // Post error to native for debugging
@@ -253,7 +411,7 @@ export function MobileEditorApp() {
         break;
       }
     }
-  }, []);
+  }, [ensureCollectionsReady]);
 
   useEffect(() => {
     const unsub = onNativeMessage(handleMessage);
@@ -261,14 +419,50 @@ export function MobileEditorApp() {
     return unsub;
   }, [handleMessage]);
 
-  if (!editorState) {
+  // Global focus tracking: report focus/blur for ALL interactive elements
+  // (inputs, textareas, selects, contentEditable) to native so keyboard
+  // avoidance works for database/record inputs, not just the TipTap editor.
+  useEffect(() => {
+    const isInteractive = (el: Element): boolean =>
+      el instanceof HTMLInputElement ||
+      el instanceof HTMLTextAreaElement ||
+      el instanceof HTMLSelectElement ||
+      (el as HTMLElement).isContentEditable;
+
+    const handleFocusIn = (e: FocusEvent) => {
+      if (e.target instanceof Element && isInteractive(e.target)) {
+        postEditorFocus(true);
+      }
+    };
+    const handleFocusOut = (e: FocusEvent) => {
+      if (e.target instanceof Element && isInteractive(e.target)) {
+        // Defer so we can check if focus moved to another interactive element
+        requestAnimationFrame(() => {
+          const next = document.activeElement;
+          if (!next || !isInteractive(next)) {
+            postEditorFocus(false);
+          }
+        });
+      }
+    };
+
+    document.addEventListener('focusin', handleFocusIn);
+    document.addEventListener('focusout', handleFocusOut);
+    return () => {
+      document.removeEventListener('focusin', handleFocusIn);
+      document.removeEventListener('focusout', handleFocusOut);
+    };
+  }, []);
+
+  if (!editorState || !runtimeReady) {
     return null;
   }
 
+  const nodeType = editorState.mode === 'record' ? 'record' : 'page';
   const node = {
     id: editorState.nodeId,
     rootId: editorState.rootId,
-    type: 'page',
+    type: nodeType,
     name: '',
     parentId: '',
     index: '',
@@ -282,30 +476,46 @@ export function MobileEditorApp() {
     serverRevision: '0',
   } as LocalNode;
 
-  const workspaceCtx = {
-    workspaceId: editorState.workspaceId,
-    accountId: editorState.accountId,
-    userId: editorState.userId,
-    role: 'owner' as WorkspaceRole,
-    collections: {} as never,
-  };
-
   return (
-    <WorkspaceContext.Provider value={workspaceCtx}>
-      <div
-        style={{
-          padding: '0 16px',
-          paddingBottom: 'env(safe-area-inset-bottom, 20px)',
-          minHeight: '100%',
-        }}
-      >
-        <DocumentEditor
-          node={node}
-          state={editorState.docState}
-          updates={editorState.docUpdates}
-          canEdit={editorState.canEdit}
-        />
-      </div>
-    </WorkspaceContext.Provider>
+    <QueryClientProvider client={queryClientRef.current}>
+      <AppContext.Provider value={{ type: 'mobile' }}>
+        <WorkspaceContext.Provider
+          value={{
+            workspaceId: editorState.workspaceId,
+            accountId: editorState.accountId,
+            userId: editorState.userId,
+            role: editorState.workspaceRole,
+            collections: collections.workspace(editorState.userId),
+          }}
+        >
+          <EditorErrorBoundary>
+            <div
+              style={{
+                padding: '0 16px',
+                paddingBottom: 'env(safe-area-inset-bottom, 20px)',
+                minHeight: '100%',
+              }}
+            >
+              {editorState.mode === 'database' ? (
+                <MobileDatabaseRuntime databaseId={editorState.nodeId} />
+              ) : editorState.mode === 'record' ? (
+                <MobileRecordRuntime
+                  recordId={editorState.nodeId}
+                  state={editorState.docState}
+                  updates={editorState.docUpdates}
+                />
+              ) : (
+                <DocumentEditor
+                  node={node}
+                  state={editorState.docState}
+                  updates={editorState.docUpdates}
+                  canEdit={editorState.canEdit}
+                />
+              )}
+            </div>
+          </EditorErrorBoundary>
+        </WorkspaceContext.Provider>
+      </AppContext.Provider>
+    </QueryClientProvider>
   );
 }

--- a/apps/mobile/webviews/editor/src/main.tsx
+++ b/apps/mobile/webviews/editor/src/main.tsx
@@ -1,16 +1,50 @@
 import './globals.css';
-import './bridge';
 
-import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
+type FatalReporterWindow = Window &
+  typeof globalThis & {
+    __colanodeReportFatal?: (message: string) => void;
+  };
 
-import { MobileEditorApp } from './editor';
+const serializeError = (error: unknown) => {
+  if (error instanceof Error) {
+    return error.stack ?? `${error.name}: ${error.message}`;
+  }
 
-const root = document.getElementById('editor-root');
-if (root) {
-  createRoot(root).render(
-    <StrictMode>
-      <MobileEditorApp />
-    </StrictMode>
-  );
-}
+  return String(error);
+};
+
+const reportFatal = (message: string, error?: unknown) => {
+  const details = error == null ? message : `${message}\n${serializeError(error)}`;
+  const fatalWindow = window as FatalReporterWindow;
+
+  fatalWindow.__colanodeReportFatal?.(details);
+  console.error('[Mobile Editor Bootstrap]', details);
+};
+
+const bootstrap = async () => {
+  try {
+    const root = document.getElementById('editor-root');
+    if (!root) {
+      reportFatal('Missing #editor-root');
+      return;
+    }
+
+    const [{ StrictMode }, { createRoot }, { MobileEditorApp }] =
+      await Promise.all([
+        import('react'),
+        import('react-dom/client'),
+        import('./editor'),
+        import('./bridge'),
+      ]);
+
+    createRoot(root).render(
+      <StrictMode>
+        <MobileEditorApp />
+      </StrictMode>
+    );
+  } catch (error) {
+    reportFatal('Bootstrap failed', error);
+  }
+};
+
+void bootstrap();

--- a/apps/mobile/webviews/editor/src/record-runtime.tsx
+++ b/apps/mobile/webviews/editor/src/record-runtime.tsx
@@ -1,0 +1,63 @@
+import type { DocumentState, DocumentUpdate, LocalRecordNode } from '@colanode/client/types';
+import { hasNodeRole } from '@colanode/core';
+import { RecordDatabase } from '@colanode/ui/components/records/record-database';
+import { RecordProvider } from '@colanode/ui/components/records/record-provider';
+import { RecordAttributes } from '@colanode/ui/components/records/record-attributes';
+import { NodeProvider } from '@colanode/ui/components/nodes/node-provider';
+import { useNode } from '@colanode/ui/contexts/node';
+import { useWorkspace } from '@colanode/ui/contexts/workspace';
+
+import { DocumentEditor } from './document-editor';
+
+interface MobileRecordRuntimeProps {
+  recordId: string;
+  state: DocumentState | null;
+  updates: DocumentUpdate[];
+}
+
+export const MobileRecordRuntime = ({
+  recordId,
+  state,
+  updates,
+}: MobileRecordRuntimeProps) => {
+  return (
+    <NodeProvider nodeId={recordId}>
+      <MobileRecordRuntimeContent state={state} updates={updates} />
+    </NodeProvider>
+  );
+};
+
+const MobileRecordRuntimeContent = ({
+  state,
+  updates,
+}: {
+  state: DocumentState | null;
+  updates: DocumentUpdate[];
+}) => {
+  const workspace = useWorkspace();
+  const { node, role } = useNode<LocalRecordNode>();
+
+  if (!node || node.type !== 'record') {
+    return null;
+  }
+
+  const canEdit =
+    node.createdBy === workspace.userId || hasNodeRole(role, 'editor');
+
+  return (
+    <RecordDatabase id={node.databaseId} role={role}>
+      <RecordProvider record={node} role={role}>
+        <div className="flex flex-col gap-3 pt-4">
+          <RecordAttributes />
+        </div>
+      </RecordProvider>
+      <div className="my-4 h-px w-full bg-border" />
+      <DocumentEditor
+        node={node}
+        state={state}
+        updates={updates}
+        canEdit={canEdit}
+      />
+    </RecordDatabase>
+  );
+};

--- a/apps/mobile/webviews/editor/src/views/database.tsx
+++ b/apps/mobile/webviews/editor/src/views/database.tsx
@@ -1,49 +1,62 @@
 import type { NodeViewProps } from '@tiptap/core';
 import { NodeViewWrapper } from '@tiptap/react';
 import { Database } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { LocalDatabaseNode } from '@colanode/client/types';
+import { NodeProvider } from '@colanode/ui/components/nodes/node-provider';
+import { useNode } from '@colanode/ui/contexts/node';
 
+import { MobileDatabaseRuntime } from '../database-runtime';
 import { postNavigateNode } from '../bridge';
 
-export const MobileDatabaseNodeView = ({ node }: NodeViewProps) => {
-  const id = node.attrs.id;
-  const [name, setName] = useState<string>('Loading...');
+const MobileDatabaseCard = ({ id }: { id: string }) => {
+  const { node } = useNode<LocalDatabaseNode>();
 
-  useEffect(() => {
-    if (!id) return;
-
-    window.colanode
-      .executeQuery({
-        type: 'node.list',
-        userId: '',
-        filters: [{ field: ['id'], operator: 'eq', value: id }],
-        sorts: [],
-        limit: 1,
-      })
-      .then((nodes) => {
-        if (nodes && nodes.length > 0) {
-          const n = nodes[0] as { name?: string };
-          setName(n.name || 'Unnamed database');
-        } else {
-          setName('Unnamed database');
-        }
-      })
-      .catch(() => {
-        setName('Unnamed database');
-      });
-  }, [id]);
-
-  if (!id) return null;
+  if (!node || node.type !== 'database') {
+    return null;
+  }
 
   return (
-    <NodeViewWrapper data-id={node.attrs.id}>
+    <NodeViewWrapper data-id={id}>
       <div
         className="my-0.5 flex h-10 w-full cursor-pointer flex-row items-center gap-2 rounded-md p-2 hover:bg-accent active:bg-accent"
         onClick={() => postNavigateNode(id, 'database')}
       >
         <Database size={18} className="text-muted-foreground shrink-0" />
-        <span className="truncate">{name}</span>
+        <span className="truncate">{node.name || 'Unnamed database'}</span>
       </div>
     </NodeViewWrapper>
+  );
+};
+
+export const MobileDatabaseNodeView = ({ node }: NodeViewProps) => {
+  const id = node.attrs.id;
+  const isInline = Boolean(node.attrs.inline);
+
+  if (!id) return null;
+
+  if (isInline) {
+    return (
+      <NodeViewWrapper
+        data-id={node.attrs.id}
+        className="my-4 w-full"
+        contentEditable={false}
+        onDragStart={(event: React.DragEvent<HTMLDivElement>) => {
+          event.stopPropagation();
+          event.preventDefault();
+        }}
+        onDragOver={(event: React.DragEvent<HTMLDivElement>) => {
+          event.preventDefault();
+          event.stopPropagation();
+        }}
+      >
+        <MobileDatabaseRuntime databaseId={id} inline />
+      </NodeViewWrapper>
+    );
+  }
+
+  return (
+    <NodeProvider nodeId={id}>
+      <MobileDatabaseCard id={id} />
+    </NodeProvider>
   );
 };


### PR DESCRIPTION
## Summary

- Add database table view screen (`database/[databaseId]`) and record detail screen (`record/[recordId]`) rendered inside the WebView using shared `@colanode/ui` database components (table view, record attributes, field value editors, view settings)
- Extend the WebView bridge protocol with query subscriptions (`query.subscribe.request`/`query.unsubscribe.request`), live event forwarding (`event.publish`), and TanStack DB collections for reactive data access
- Render inline databases inside pages via the TipTap editor — non-inline databases show as navigable cards
- Add global `focusin`/`focusout` tracking so keyboard avoidance works for all interactive elements (not just the TipTap editor)
- Fix flush on navigation/background: use a callback registry (`__flushCallbacks`) and blur active inputs to commit pending debounced mutations before the WebView is torn down
- Fix WKWebView error masking: use file-based `baseUrl` instead of empty string so error details are no longer stripped as "Script error"
- Add React `EditorErrorBoundary` in the WebView for actionable error reporting
- Update mobile README to reflect database/record support, document intentional `database-runtime.tsx` duplication (shared `packages/ui` table components include desktop-only drag-and-drop/resize), and refresh bridge protocol docs

## Test plan

- [ ] Open a page containing an inline database — verify the table renders and rows are interactive (click to edit name, field values, expand to record)
- [ ] Navigate to a standalone database screen — verify view tabs, filters, sorts, and record creation work
- [ ] Open a record — verify attributes and rich-text body render and are editable
- [ ] Edit a field value and immediately navigate back — verify the edit is not lost
- [ ] Focus an input inside a database near the bottom of the screen — verify keyboard scrolls it into view
- [ ] Verify page editing (non-database) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)