### PR TITLE
Mobile: De-duplicate database view logic into shared packages/ui

### DIFF
--- a/apps/mobile/src/components/nodes/rename-node-sheet.tsx
+++ b/apps/mobile/src/components/nodes/rename-node-sheet.tsx
@@ -34,6 +34,7 @@ const NODE_TYPE_LABELS: Record<string, string> = {
   channel: 'Channel',
   page: 'Page',
   folder: 'Folder',
+  database: 'Database',
 };
 
 const buildAttributes = (
@@ -72,6 +73,16 @@ const buildAttributes = (
         avatar: newAvatar ?? null,
         parentId: node.parentId!,
       };
+    case 'database':
+      return {
+        type: 'database',
+        name: newName,
+        avatar: newAvatar ?? null,
+        parentId: node.parentId!,
+        fields: node.fields ?? {},
+        nameField: node.nameField ?? null,
+        locked: node.locked ?? null,
+      };
     default:
       throw new Error(`Unsupported node type for rename: ${node.type}`);
   }
@@ -99,7 +110,7 @@ export const RenameNodeSheet = ({
   const toast = useToast();
 
   useEffect(() => {
-    if (visible && node && (node.type === 'space' || node.type === 'channel' || node.type === 'page' || node.type === 'folder')) {
+    if (visible && node && (node.type === 'space' || node.type === 'channel' || node.type === 'page' || node.type === 'folder' || node.type === 'database')) {
       setName(node.name ?? '');
       setAvatar(getNodeAvatar(node));
       setShowAvatarPicker(false);

--- a/apps/mobile/webviews/editor/src/database-runtime.tsx
+++ b/apps/mobile/webviews/editor/src/database-runtime.tsx
@@ -1,91 +1,25 @@
-import { eq, useLiveQuery } from '@tanstack/react-db';
-import { InView } from 'react-intersection-observer';
-import {
-  Fullscreen,
-  Lock,
-  LockOpen,
-  SquareArrowOutUpRight,
-  Trash2,
-} from 'lucide-react';
-import { useEffect, useState } from 'react';
-
-import {
-  LocalDatabaseNode,
-  LocalDatabaseViewNode,
-  LocalRecordNode,
-  ViewField,
-} from '@colanode/client/types';
-import {
-  compareString,
-  DatabaseViewFilterAttributes,
-  DatabaseViewSortAttributes,
-  IdType,
-  SpecialId,
-  SortDirection,
-  extractNodeRole,
-  generateId,
-} from '@colanode/core';
+import type { LocalDatabaseNode, LocalDatabaseViewNode } from '@colanode/client/types';
 import { DatabaseNotFound } from '@colanode/ui/components/databases/database-not-found';
 import { Database } from '@colanode/ui/components/databases/database';
-import { ViewAvatarInput } from '@colanode/ui/components/databases/view-avatar-input';
-import { ViewFieldSettings } from '@colanode/ui/components/databases/view-field-settings';
-import { ViewRenameInput } from '@colanode/ui/components/databases/view-rename-input';
-import { ViewSettingsButton } from '@colanode/ui/components/databases/view-settings-button';
-import { ViewTab } from '@colanode/ui/components/databases/view-tab';
-import {
-  AlertDialog,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@colanode/ui/components/ui/alert-dialog';
-import { Button } from '@colanode/ui/components/ui/button';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@colanode/ui/components/ui/popover';
-import { Separator } from '@colanode/ui/components/ui/separator';
-import { DatabaseViewsContext } from '@colanode/ui/contexts/database-views';
-import { DatabaseViewContext } from '@colanode/ui/contexts/database-view';
-import { useDatabase } from '@colanode/ui/contexts/database';
-import { useDatabaseView } from '@colanode/ui/contexts/database-view';
-import { useDatabaseViews } from '@colanode/ui/contexts/database-views';
-import { useNode } from '@colanode/ui/contexts/node';
-import { useWorkspace } from '@colanode/ui/contexts/workspace';
-import { TableViewEmptyPlaceholder } from '@colanode/ui/components/databases/tables/table-view-empty-placeholder';
-import { TableViewRecordCreateRow } from '@colanode/ui/components/databases/tables/table-view-record-create-row';
+import { DatabaseViews } from '@colanode/ui/components/databases/database-views';
 import { ViewFilterButton } from '@colanode/ui/components/databases/search/view-filter-button';
 import { ViewSearchBar } from '@colanode/ui/components/databases/search/view-search-bar';
 import { ViewSortButton } from '@colanode/ui/components/databases/search/view-sort-button';
+import { TableViewBody } from '@colanode/ui/components/databases/tables/table-view-body';
+import { TableViewRecordCreateRow } from '@colanode/ui/components/databases/tables/table-view-record-create-row';
+import { TableViewSettings } from '@colanode/ui/components/databases/tables/table-view-settings';
+import { ViewFullscreenButton } from '@colanode/ui/components/databases/view-fullscreen-button';
+import { ViewTabs } from '@colanode/ui/components/databases/view-tabs';
 import { NodeProvider } from '@colanode/ui/components/nodes/node-provider';
-import { RecordFieldValue } from '@colanode/ui/components/records/record-field-value';
-import { RecordProvider } from '@colanode/ui/components/records/record-provider';
-import { useRecord } from '@colanode/ui/contexts/record';
-import { useMetadata } from '@colanode/ui/hooks/use-metadata';
-import { useRecordsQuery } from '@colanode/ui/hooks/use-records-query';
-import {
-  generateFieldValuesFromFilters,
-  getDefaultFieldWidth,
-  getDefaultNameWidth,
-  getDefaultViewFieldDisplay,
-} from '@colanode/ui/lib/databases';
-
-import { postNavigateNode } from './bridge';
+import { useDatabase } from '@colanode/ui/contexts/database';
+import { DatabaseViewContext } from '@colanode/ui/contexts/database-view';
+import { useDatabaseView } from '@colanode/ui/contexts/database-view';
+import { useDatabaseViews } from '@colanode/ui/contexts/database-views';
+import { useNode } from '@colanode/ui/contexts/node';
+import { useDatabaseViewValue } from '@colanode/ui/hooks/use-database-view-value';
 
 interface MobileDatabaseRuntimeProps {
   databaseId: string;
-  inline?: boolean;
-}
-
-interface MobileDatabaseViewsProps {
-  inline?: boolean;
-}
-
-interface MobileDatabaseViewProps {
-  view: LocalDatabaseViewNode;
   inline?: boolean;
 }
 
@@ -100,11 +34,7 @@ export const MobileDatabaseRuntime = ({
   );
 };
 
-const MobileDatabaseRuntimeContent = ({
-  inline,
-}: {
-  inline: boolean;
-}) => {
+const MobileDatabaseRuntimeContent = ({ inline }: { inline: boolean }) => {
   const { node, role } = useNode<LocalDatabaseNode>();
 
   if (!node || node.type !== 'database') {
@@ -113,209 +43,27 @@ const MobileDatabaseRuntimeContent = ({
 
   return (
     <Database database={node} role={role}>
-      <MobileDatabaseViews inline={inline} />
+      <DatabaseViews
+        inline={inline}
+        renderLayout={({ view, inline: isInline }) => (
+          <MobileLayout view={view} inline={isInline} />
+        )}
+      />
     </Database>
   );
 };
 
-const MobileDatabaseViews = ({
-  inline = false,
-}: MobileDatabaseViewsProps) => {
-  const workspace = useWorkspace();
-  const database = useDatabase();
-
-  const [activeViewId, setActiveViewId] = useMetadata<string>(
-    workspace.userId,
-    `${database.id}.activeViewId`
-  );
-
-  const viewsQuery = useLiveQuery(
-    (q) =>
-      q
-        .from({ nodes: workspace.collections.nodes })
-        .where(({ nodes }) => eq(nodes.type, 'database_view'))
-        .where(({ nodes }) => eq(nodes.parentId, database.id)),
-    [workspace.userId, database.id]
-  );
-
-  const views = (viewsQuery.data ?? [])
-    .map((node) => node as LocalDatabaseViewNode)
-    .sort((a, b) => compareString(a.index, b.index));
-
-  const activeView = views.find((view) => view.id === activeViewId) ?? views[0];
-
-  if (!activeView) {
-    return null;
-  }
-
-  return (
-    <DatabaseViewsContext.Provider
-      value={{
-        views,
-        activeViewId: activeView.id,
-        onActiveViewChange: setActiveViewId,
-        inline,
-      }}
-    >
-      <MobileDatabaseView view={activeView} inline={inline} />
-    </DatabaseViewsContext.Provider>
-  );
-};
-
-const MobileDatabaseView = ({
+const MobileLayout = ({
   view,
-  inline = false,
-}: MobileDatabaseViewProps) => {
-  const workspace = useWorkspace();
-  const database = useDatabase();
-
-  const fields: ViewField[] = database.fields
-    .map((field) => {
-      const viewField = view.fields?.[field.id];
-
-      return {
-        field,
-        display: viewField?.display ?? getDefaultViewFieldDisplay(view.layout),
-        index: viewField?.index ?? field.index,
-        width: viewField?.width ?? getDefaultFieldWidth(field.type),
-      };
-    })
-    .filter((field) => field.display)
-    .sort((a, b) => compareString(a.index, b.index));
-
-  const [isSearchBarOpened, setIsSearchBarOpened] = useState(false);
-  const [isSortsOpened, setIsSortsOpened] = useState(false);
-  const [openedFieldFilters, setOpenedFieldFilters] = useState<string[]>([]);
+  inline,
+}: {
+  view: LocalDatabaseViewNode;
+  inline: boolean;
+}) => {
+  const contextValue = useDatabaseViewValue(view);
 
   return (
-    <DatabaseViewContext.Provider
-      value={{
-        id: view.id,
-        name: view.name,
-        avatar: view.avatar,
-        layout: view.layout,
-        fields,
-        filters: Object.values(view.filters ?? {}),
-        sorts: Object.values(view.sorts ?? {}),
-        groupBy: view.groupBy,
-        nameWidth: view.nameWidth ?? getDefaultNameWidth(),
-        isSearchBarOpened: isSearchBarOpened || openedFieldFilters.length > 0,
-        isSortsOpened,
-        isFieldFilterOpened: (fieldId: string) =>
-          openedFieldFilters.includes(fieldId),
-        initFieldFilter: (fieldId: string) => {
-          workspace.collections.nodes.update(view.id, (draft) => {
-            if (draft.type !== 'database_view') return;
-
-            const existingFilter = draft.filters?.[fieldId];
-            if (existingFilter) {
-              setOpenedFieldFilters((prev) =>
-                prev.filter((id) => id !== fieldId)
-              );
-              return;
-            }
-
-            if (
-              fieldId !== SpecialId.Name &&
-              !database.fields.find((field) => field.id === fieldId)
-            ) {
-              return;
-            }
-
-            const filter: DatabaseViewFilterAttributes = {
-              id: fieldId,
-              fieldId,
-              type: 'field',
-              operator: 'equals',
-              value: '',
-            };
-
-            draft.filters = {
-              ...draft.filters,
-              [fieldId]: filter,
-            };
-
-            setOpenedFieldFilters((prev) => [...prev, fieldId]);
-          });
-        },
-        initFieldSort: (fieldId: string, direction: SortDirection) => {
-          if (!database.canEdit || database.isLocked) {
-            return;
-          }
-
-          workspace.collections.nodes.update(view.id, (draft) => {
-            if (draft.type !== 'database_view') return;
-
-            const existingSort = draft.sorts?.[fieldId];
-            if (existingSort && existingSort.direction === direction) {
-              return;
-            }
-
-            if (
-              fieldId !== SpecialId.Name &&
-              !database.fields.find((field) => field.id === fieldId)
-            ) {
-              return;
-            }
-
-            const sort: DatabaseViewSortAttributes = {
-              id: fieldId,
-              fieldId,
-              direction,
-            };
-
-            draft.sorts = {
-              ...draft.sorts,
-              [fieldId]: sort,
-            };
-          });
-        },
-        openSearchBar: () => setIsSearchBarOpened(true),
-        closeSearchBar: () => setIsSearchBarOpened(false),
-        openSorts: () => setIsSortsOpened(true),
-        closeSorts: () => setIsSortsOpened(false),
-        openFieldFilter: (fieldId: string) => {
-          setOpenedFieldFilters((prev) => [...prev, fieldId]);
-        },
-        closeFieldFilter: (fieldId: string) => {
-          setOpenedFieldFilters((prev) => prev.filter((id) => id !== fieldId));
-        },
-        createRecord: (filters?: DatabaseViewFilterAttributes[]) => {
-          if (!database.canCreateRecord || database.isLocked) {
-            return;
-          }
-
-          const allFilters = [
-            ...(Object.values(view.filters ?? {}) ?? []),
-            ...(filters ?? []),
-          ];
-
-          const recordId = generateId(IdType.Record);
-          const record: LocalRecordNode = {
-            id: recordId,
-            type: 'record',
-            parentId: database.id,
-            rootId: database.rootId,
-            databaseId: database.id,
-            name: '',
-            fields: generateFieldValuesFromFilters(
-              database.fields,
-              allFilters,
-              workspace.userId
-            ),
-            createdAt: new Date().toISOString(),
-            createdBy: workspace.userId,
-            updatedAt: null,
-            updatedBy: null,
-            localRevision: '0',
-            serverRevision: '0',
-          };
-
-          workspace.collections.nodes.insert(record);
-          postNavigateNode(record.id, 'record');
-        },
-      }}
-    >
+    <DatabaseViewContext.Provider value={contextValue}>
       {view.layout === 'table' ? (
         <MobileTableView inline={inline} />
       ) : (
@@ -325,155 +73,14 @@ const MobileDatabaseView = ({
   );
 };
 
-const MobileInlineFullscreenButton = () => {
-  const database = useDatabase();
-  const views = useDatabaseViews();
-
-  if (!views.inline) {
-    return null;
-  }
-
-  return (
-    <button
-      type="button"
-      className="flex cursor-pointer items-center rounded-md p-1.5 hover:bg-accent"
-      onClick={() => postNavigateNode(database.id, 'database')}
-    >
-      <Fullscreen className="size-4" />
-    </button>
-  );
-};
-
-const MobileViewTabs = () => {
-  const databaseViews = useDatabaseViews();
-
-  return (
-    <div className="flex flex-row items-center gap-3 overflow-x-auto pr-2">
-      {databaseViews.views.map((view) => (
-        <ViewTab
-          key={view.id}
-          view={view}
-          isActive={view.id === databaseViews.activeViewId}
-          onClick={() => databaseViews.onActiveViewChange(view.id)}
-        />
-      ))}
-    </div>
-  );
-};
-
-const MobileViewSettings = () => {
-  const workspace = useWorkspace();
-  const database = useDatabase();
-  const view = useDatabaseView();
-  const databaseViews = useDatabaseViews();
-
-  const [open, setOpen] = useState(false);
-  const [openDelete, setOpenDelete] = useState(false);
-
-  const canDeleteView = databaseViews.views.length > 1;
-
-  const handleDeleteView = () => {
-    const nextViewId =
-      databaseViews.views.find((candidate) => candidate.id !== view.id)?.id ??
-      '';
-
-    workspace.collections.nodes.delete(view.id);
-    databaseViews.onActiveViewChange(nextViewId);
-    setOpenDelete(false);
-    setOpen(false);
-  };
-
-  return (
-    <>
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger>
-          <ViewSettingsButton />
-        </PopoverTrigger>
-        <PopoverContent className="mr-4 flex w-90 flex-col gap-1.5 p-2">
-          <div className="flex flex-row items-center gap-2">
-            <ViewAvatarInput
-              id={view.id}
-              name={view.name}
-              avatar={view.avatar}
-              layout={view.layout}
-              readOnly={!database.canEdit || database.isLocked}
-            />
-            <ViewRenameInput
-              id={view.id}
-              name={view.name}
-              readOnly={!database.canEdit || database.isLocked}
-            />
-          </div>
-          <Separator />
-          <ViewFieldSettings />
-          {database.canEdit && (
-            <>
-              <Separator />
-              <div className="flex flex-col gap-2 text-sm">
-                <p className="my-1 font-semibold">Settings</p>
-                <div
-                  className="flex cursor-pointer flex-row items-center gap-1 rounded-md p-0.5 hover:bg-accent"
-                  onClick={() => {
-                    database.toggleLock();
-                  }}
-                >
-                  {database.isLocked ? (
-                    <LockOpen className="size-4" />
-                  ) : (
-                    <Lock className="size-4" />
-                  )}
-                  <span>
-                    {database.isLocked ? 'Unlock database' : 'Lock database'}
-                  </span>
-                </div>
-                {canDeleteView && !database.isLocked && (
-                  <div
-                    className="flex cursor-pointer flex-row items-center gap-1 rounded-md p-0.5 hover:bg-accent"
-                    onClick={() => {
-                      setOpenDelete(true);
-                      setOpen(false);
-                    }}
-                  >
-                    <Trash2 className="size-4" />
-                    <span>Delete view</span>
-                  </div>
-                )}
-              </div>
-            </>
-          )}
-        </PopoverContent>
-      </Popover>
-      <AlertDialog open={openDelete} onOpenChange={setOpenDelete}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              Are you sure you want delete this view?
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              This action cannot be undone. This view will no longer be
-              accessible and all data in the view will be lost.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <Button variant="destructive" onClick={handleDeleteView}>
-              Delete
-            </Button>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </>
-  );
-};
-
 const MobileTableView = ({ inline }: { inline: boolean }) => {
   return (
     <div className="w-full h-full group/database">
       <div className="flex flex-row justify-between border-b gap-2">
-        <MobileViewTabs />
+        <ViewTabs />
         <div className="flex flex-row items-center justify-end gap-1">
-          {inline && <MobileInlineFullscreenButton />}
-          <MobileViewSettings />
+          {inline && <ViewFullscreenButton />}
+          <TableViewSettings />
           <ViewSortButton />
           <ViewFilterButton />
         </div>
@@ -481,7 +88,7 @@ const MobileTableView = ({ inline }: { inline: boolean }) => {
       <ViewSearchBar />
       <div className="mt-2 w-full min-w-full max-w-full overflow-auto pr-1">
         <MobileTableViewHeader />
-        <MobileTableViewBody />
+        <TableViewBody />
         <MobileTableViewRecordCreateRow />
       </div>
     </div>
@@ -520,6 +127,16 @@ const MobileTableViewHeader = () => {
   );
 };
 
+const MobileTableViewRecordCreateRow = () => {
+  const database = useDatabase();
+
+  if (!database.canCreateRecord || database.isLocked) {
+    return null;
+  }
+
+  return <TableViewRecordCreateRow />;
+};
+
 const MobileUnsupportedView = ({ inline }: { inline: boolean }) => {
   const view = useDatabaseView();
   const databaseViews = useDatabaseViews();
@@ -536,10 +153,10 @@ const MobileUnsupportedView = ({ inline }: { inline: boolean }) => {
   return (
     <div className="w-full h-full group/database">
       <div className="flex flex-row justify-between border-b gap-2">
-        <MobileViewTabs />
+        <ViewTabs />
         <div className="flex flex-row items-center justify-end gap-1">
-          {inline && <MobileInlineFullscreenButton />}
-          <MobileViewSettings />
+          {inline && <ViewFullscreenButton />}
+          <TableViewSettings />
         </div>
       </div>
       <div className="flex min-h-[280px] flex-col items-center justify-center gap-3 px-4 py-8 text-center">
@@ -566,168 +183,6 @@ const MobileUnsupportedView = ({ inline }: { inline: boolean }) => {
           </p>
         )}
       </div>
-    </div>
-  );
-};
-
-const MobileTableViewBody = () => {
-  const view = useDatabaseView();
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useRecordsQuery(view.filters, view.sorts);
-  const records = data ?? [];
-
-  return (
-    <div className="border-t">
-      {records.length === 0 && <TableViewEmptyPlaceholder />}
-      {records.map((record, index) => (
-        <MobileTableViewRow key={record.id} index={index} record={record} />
-      ))}
-      <InView
-        rootMargin="200px"
-        onChange={(inView) => {
-          if (inView && hasNextPage && !isFetchingNextPage) {
-            fetchNextPage();
-          }
-        }}
-      />
-    </div>
-  );
-};
-
-const MobileTableViewRow = ({
-  index,
-  record,
-}: {
-  index: number;
-  record: LocalRecordNode;
-}) => {
-  const workspace = useWorkspace();
-  const database = useDatabase();
-  const view = useDatabaseView();
-  const role = extractNodeRole(record, workspace.userId) ?? database.role;
-
-  return (
-    <RecordProvider record={record} role={role}>
-      <div className="animate-fade-in flex flex-row items-center gap-0.5 border-b">
-        <span
-          className="flex items-center justify-center text-sm text-muted-foreground"
-          style={{ width: '30px', minWidth: '30px' }}
-        >
-          {index + 1}
-        </span>
-        <div
-          className="h-8 border-r overflow-hidden"
-          style={{ width: `${view.nameWidth}px`, minWidth: '240px' }}
-        >
-          <MobileTableViewNameCell record={record} />
-        </div>
-        {view.fields.map((field) => (
-          <div
-            key={`row-${record.id}-${field.field.id}`}
-            className="h-8 border-r p-1 overflow-hidden"
-            style={{ width: `${field.width}px`, minWidth: '120px' }}
-          >
-            <RecordFieldValue field={field.field} readOnly={database.isLocked} />
-          </div>
-        ))}
-        <div className="w-2" />
-      </div>
-    </RecordProvider>
-  );
-};
-
-const MobileTableViewRecordCreateRow = () => {
-  const database = useDatabase();
-
-  if (!database.canCreateRecord || database.isLocked) {
-    return null;
-  }
-
-  return <TableViewRecordCreateRow />;
-};
-
-const MobileTableViewNameCell = ({ record }: { record: LocalRecordNode }) => {
-  const workspace = useWorkspace();
-  const database = useDatabase();
-  const currentRecord = useRecord();
-  const [isEditing, setIsEditing] = useState(false);
-  const [value, setValue] = useState(record.name ?? '');
-  const canEditName = currentRecord.canEdit && !database.isLocked;
-
-  useEffect(() => {
-    if (!isEditing) {
-      setValue(record.name ?? '');
-    }
-  }, [isEditing, record.name]);
-
-  const save = () => {
-    if (!canEditName) {
-      setIsEditing(false);
-      return;
-    }
-
-    if (value !== record.name) {
-      workspace.collections.nodes.update(record.id, (draft) => {
-        if (draft.type !== 'record') {
-          return;
-        }
-
-        draft.name = value;
-      });
-    }
-
-    setIsEditing(false);
-  };
-
-  return (
-    <div className="group relative flex h-full w-full items-center">
-      {isEditing ? (
-        <input
-          value={value}
-          onChange={(event) => setValue(event.target.value)}
-          onBlur={save}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter') {
-              event.preventDefault();
-              save();
-            }
-            if (event.key === 'Escape') {
-              event.preventDefault();
-              setValue(record.name ?? '');
-              setIsEditing(false);
-            }
-          }}
-          className="flex h-full w-full cursor-text flex-row items-center gap-1 p-1 text-sm outline-none"
-          autoFocus
-        />
-      ) : (
-        <>
-          <button
-            type="button"
-            onClick={() => {
-              if (!canEditName) {
-                return;
-              }
-
-              setIsEditing(true);
-            }}
-            className="flex h-full w-full cursor-pointer flex-row items-center gap-1 p-1 text-sm text-left"
-          >
-            {record.name ? (
-              <span className="truncate">{record.name}</span>
-            ) : (
-              <span className="text-muted-foreground">Unnamed</span>
-            )}
-          </button>
-          <button
-            type="button"
-            className="absolute right-2 flex h-6 cursor-pointer flex-row items-center gap-1 rounded-md border p-1 text-sm text-muted-foreground hover:bg-accent"
-            onClick={() => postNavigateNode(record.id, 'record')}
-          >
-            <SquareArrowOutUpRight className="size-4" />
-          </button>
-        </>
-      )}
     </div>
   );
 };

--- a/apps/mobile/webviews/editor/src/editor.tsx
+++ b/apps/mobile/webviews/editor/src/editor.tsx
@@ -7,6 +7,7 @@ import type { LocalNode } from '@colanode/client/types/nodes';
 import { WorkspaceStatus, type WorkspaceRole } from '@colanode/core';
 import { AppContext } from '@colanode/ui/contexts/app';
 import { collections } from '@colanode/ui/collections';
+import { NavigationContext } from '@colanode/ui/contexts/navigation';
 import { WorkspaceContext } from '@colanode/ui/contexts/workspace';
 import { buildQueryClient } from '@colanode/ui/lib/query';
 import { DatabaseCommand, DatabaseInlineCommand } from '@colanode/ui/editor/commands';
@@ -17,6 +18,7 @@ import {
   onNativeMessage,
   postEditorFocus,
   postError,
+  postNavigateNode,
   postReady,
   type NativeToWebViewMessage,
 } from './bridge';
@@ -488,6 +490,9 @@ export function MobileEditorApp() {
             collections: collections.workspace(editorState.userId),
           }}
         >
+          <NavigationContext.Provider
+            value={{ openNode: postNavigateNode }}
+          >
           <EditorErrorBoundary>
             <div
               style={{
@@ -514,6 +519,7 @@ export function MobileEditorApp() {
               )}
             </div>
           </EditorErrorBoundary>
+          </NavigationContext.Provider>
         </WorkspaceContext.Provider>
       </AppContext.Provider>
     </QueryClientProvider>

--- a/packages/ui/src/components/databases/database-views.tsx
+++ b/packages/ui/src/components/databases/database-views.tsx
@@ -1,4 +1,5 @@
 import { eq, useLiveQuery } from '@tanstack/react-db';
+import type { ReactNode } from 'react';
 
 import { LocalDatabaseViewNode } from '@colanode/client/types';
 import { View } from '@colanode/ui/components/databases/view';
@@ -9,9 +10,16 @@ import { useMetadata } from '@colanode/ui/hooks/use-metadata';
 
 interface DatabaseViewsProps {
   inline?: boolean;
+  renderLayout?: (props: {
+    view: LocalDatabaseViewNode;
+    inline: boolean;
+  }) => ReactNode;
 }
 
-export const DatabaseViews = ({ inline = false }: DatabaseViewsProps) => {
+export const DatabaseViews = ({
+  inline = false,
+  renderLayout,
+}: DatabaseViewsProps) => {
   const workspace = useWorkspace();
   const database = useDatabase();
 
@@ -47,7 +55,10 @@ export const DatabaseViews = ({ inline = false }: DatabaseViewsProps) => {
         inline,
       }}
     >
-      {activeView && <View view={activeView} />}
+      {activeView &&
+        (renderLayout
+          ? renderLayout({ view: activeView, inline })
+          : <View view={activeView} />)}
     </DatabaseViewsContext.Provider>
   );
 };

--- a/packages/ui/src/components/databases/tables/table-view-name-cell.tsx
+++ b/packages/ui/src/components/databases/tables/table-view-name-cell.tsx
@@ -3,7 +3,10 @@ import { SquareArrowOutUpRight } from 'lucide-react';
 import React, { Fragment } from 'react';
 
 import { RecordNode } from '@colanode/core';
-import { Link } from '@colanode/ui/components/ui/link';
+import { useApp } from '@colanode/ui/contexts/app';
+import { useDatabase } from '@colanode/ui/contexts/database';
+import { useNavigation } from '@colanode/ui/contexts/navigation';
+import { useRecord } from '@colanode/ui/contexts/record';
 import { useWorkspace } from '@colanode/ui/contexts/workspace';
 
 interface NameEditorProps {
@@ -55,10 +58,15 @@ interface TableViewNameCellProps {
 }
 
 export const TableViewNameCell = ({ record }: TableViewNameCellProps) => {
+  const app = useApp();
   const workspace = useWorkspace();
+  const database = useDatabase();
+  const currentRecord = useRecord();
+  const navigation = useNavigation();
   const [isEditing, setIsEditing] = React.useState(false);
 
-  const canEdit = true;
+  const isMobile = app.type === 'mobile';
+  const canEdit = currentRecord.canEdit && !database.isLocked;
   const hasName = record.name && record.name.length > 0;
 
   const handleSave = (newName: string) => {
@@ -95,14 +103,13 @@ export const TableViewNameCell = ({ record }: TableViewNameCellProps) => {
               <span className="text-muted-foreground">Unnamed</span>
             )}
           </div>
-          <Link
-            from="/workspace/$userId/$nodeId"
-            to="modal/$modalNodeId"
-            params={{ modalNodeId: record.id }}
-            className="absolute right-2 flex h-6 cursor-pointer flex-row items-center gap-1 rounded-md border p-1 text-sm text-muted-foreground opacity-0 hover:bg-accent group-hover:opacity-100"
+          <button
+            type="button"
+            className={`absolute right-2 flex h-6 cursor-pointer flex-row items-center gap-1 rounded-md border p-1 text-sm text-muted-foreground hover:bg-accent ${isMobile ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}`}
+            onClick={() => navigation.openNode(record.id, 'record')}
           >
-            <SquareArrowOutUpRight className="mr-1 size-4" /> <p>Open</p>
-          </Link>
+            <SquareArrowOutUpRight className="size-4" />
+          </button>
         </Fragment>
       )}
     </div>

--- a/packages/ui/src/components/databases/tables/table-view-row.tsx
+++ b/packages/ui/src/components/databases/tables/table-view-row.tsx
@@ -22,14 +22,14 @@ export const TableViewRow = ({ index, record }: TableViewRowProps) => {
     <RecordProvider record={record} role={role}>
       <div className="animate-fade-in flex flex-row items-center gap-0.5 border-b">
         <span
-          className="flex cursor-pointer items-center justify-center text-sm text-muted-foreground"
+          className="flex items-center justify-center text-sm text-muted-foreground"
           style={{ width: '30px', minWidth: '30px' }}
         >
           {index + 1}
         </span>
         <div
           className="h-8 border-r overflow-hidden"
-          style={{ width: `${view.nameWidth}px`, minWidth: '300px' }}
+          style={{ width: `${view.nameWidth}px`, minWidth: '240px' }}
         >
           <TableViewNameCell record={record} />
         </div>
@@ -38,13 +38,16 @@ export const TableViewRow = ({ index, record }: TableViewRowProps) => {
             <div
               key={`row-${record.id}-${field.field.id}`}
               className="h-8 border-r p-1 overflow-hidden"
-              style={{ width: `${field.width}px` }}
+              style={{ width: `${field.width}px`, minWidth: '120px' }}
             >
-              <RecordFieldValue field={field.field} />
+              <RecordFieldValue
+                field={field.field}
+                readOnly={database.isLocked}
+              />
             </div>
           );
         })}
-        <div className="w-8" />
+        <div className="w-2" />
       </div>
     </RecordProvider>
   );

--- a/packages/ui/src/components/databases/tables/table-view-settings.tsx
+++ b/packages/ui/src/components/databases/tables/table-view-settings.tsx
@@ -5,7 +5,16 @@ import { ViewAvatarInput } from '@colanode/ui/components/databases/view-avatar-i
 import { ViewFieldSettings } from '@colanode/ui/components/databases/view-field-settings';
 import { ViewRenameInput } from '@colanode/ui/components/databases/view-rename-input';
 import { ViewSettingsButton } from '@colanode/ui/components/databases/view-settings-button';
-import { NodeDeleteDialog } from '@colanode/ui/components/nodes/node-delete-dialog';
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@colanode/ui/components/ui/alert-dialog';
+import { Button } from '@colanode/ui/components/ui/button';
 import {
   Popover,
   PopoverContent,
@@ -14,13 +23,30 @@ import {
 import { Separator } from '@colanode/ui/components/ui/separator';
 import { useDatabase } from '@colanode/ui/contexts/database';
 import { useDatabaseView } from '@colanode/ui/contexts/database-view';
+import { useDatabaseViews } from '@colanode/ui/contexts/database-views';
+import { useWorkspace } from '@colanode/ui/contexts/workspace';
 
 export const TableViewSettings = () => {
+  const workspace = useWorkspace();
   const database = useDatabase();
   const view = useDatabaseView();
+  const databaseViews = useDatabaseViews();
 
   const [open, setOpen] = useState(false);
   const [openDelete, setOpenDelete] = useState(false);
+
+  const canDeleteView = databaseViews.views.length > 1;
+
+  const handleDeleteView = () => {
+    const nextViewId =
+      databaseViews.views.find((candidate) => candidate.id !== view.id)?.id ??
+      '';
+
+    workspace.collections.nodes.delete(view.id);
+    databaseViews.onActiveViewChange(nextViewId);
+    setOpenDelete(false);
+    setOpen(false);
+  };
 
   return (
     <Fragment>
@@ -65,7 +91,7 @@ export const TableViewSettings = () => {
                     {database.isLocked ? 'Unlock database' : 'Lock database'}
                   </span>
                 </div>
-                {!database.isLocked && (
+                {canDeleteView && !database.isLocked && (
                   <div
                     className="flex cursor-pointer flex-row items-center gap-1 rounded-md p-0.5 hover:bg-accent"
                     onClick={() => {
@@ -82,15 +108,25 @@ export const TableViewSettings = () => {
           )}
         </PopoverContent>
       </Popover>
-      {openDelete && (
-        <NodeDeleteDialog
-          title="Are you sure you want delete this view?"
-          description="This action cannot be undone. This view will no longer be accessible and all data in the view will be lost."
-          id={view.id}
-          open={openDelete}
-          onOpenChange={setOpenDelete}
-        />
-      )}
+      <AlertDialog open={openDelete} onOpenChange={setOpenDelete}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Are you sure you want delete this view?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone. This view will no longer be
+              accessible and all data in the view will be lost.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <Button variant="destructive" onClick={handleDeleteView}>
+              Delete
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Fragment>
   );
 };

--- a/packages/ui/src/components/databases/view-fullscreen-button.tsx
+++ b/packages/ui/src/components/databases/view-fullscreen-button.tsx
@@ -1,25 +1,25 @@
 import { Fullscreen } from 'lucide-react';
 
-import { Link } from '@colanode/ui/components/ui/link';
 import { useDatabase } from '@colanode/ui/contexts/database';
 import { useDatabaseViews } from '@colanode/ui/contexts/database-views';
+import { useNavigation } from '@colanode/ui/contexts/navigation';
 
 export const ViewFullscreenButton = () => {
   const database = useDatabase();
   const views = useDatabaseViews();
+  const navigation = useNavigation();
 
   if (!views.inline) {
     return null;
   }
 
   return (
-    <Link
-      from="/workspace/$userId"
-      to="$nodeId"
-      params={{ nodeId: database.id }}
+    <button
+      type="button"
       className="flex cursor-pointer items-center rounded-md p-1.5 hover:bg-accent"
+      onClick={() => navigation.openNode(database.id, 'database')}
     >
       <Fullscreen className="size-4" />
-    </Link>
+    </button>
   );
 };

--- a/packages/ui/src/components/databases/view-tabs.tsx
+++ b/packages/ui/src/components/databases/view-tabs.tsx
@@ -8,7 +8,7 @@ export const ViewTabs = () => {
   const databaseViews = useDatabaseViews();
 
   return (
-    <div className="flex flex-row items-center gap-3">
+    <div className="flex flex-row items-center gap-3 overflow-x-auto">
       {databaseViews.views.map((view) => (
         <ViewTab
           key={view.id}

--- a/packages/ui/src/components/databases/view.tsx
+++ b/packages/ui/src/components/databases/view.tsx
@@ -1,206 +1,21 @@
-import { useNavigate } from '@tanstack/react-router';
-import { useState } from 'react';
 import { match } from 'ts-pattern';
 
-import {
-  LocalDatabaseViewNode,
-  LocalRecordNode,
-  ViewField,
-} from '@colanode/client/types';
-import {
-  compareString,
-  SortDirection,
-  DatabaseViewFilterAttributes,
-  DatabaseViewSortAttributes,
-  SpecialId,
-  generateId,
-  IdType,
-} from '@colanode/core';
+import { LocalDatabaseViewNode } from '@colanode/client/types';
 import { BoardView } from '@colanode/ui/components/databases/boards/board-view';
 import { CalendarView } from '@colanode/ui/components/databases/calendars/calendar-view';
 import { TableView } from '@colanode/ui/components/databases/tables/table-view';
-import { useDatabase } from '@colanode/ui/contexts/database';
 import { DatabaseViewContext } from '@colanode/ui/contexts/database-view';
-import { useWorkspace } from '@colanode/ui/contexts/workspace';
-import {
-  generateFieldValuesFromFilters,
-  getDefaultFieldWidth,
-  getDefaultNameWidth,
-  getDefaultViewFieldDisplay,
-} from '@colanode/ui/lib/databases';
+import { useDatabaseViewValue } from '@colanode/ui/hooks/use-database-view-value';
 
 interface ViewProps {
   view: LocalDatabaseViewNode;
 }
 
 export const View = ({ view }: ViewProps) => {
-  const workspace = useWorkspace();
-  const database = useDatabase();
-  const navigate = useNavigate();
-
-  const fields: ViewField[] = database.fields
-    .map((field) => {
-      const viewField = view.fields?.[field.id];
-
-      return {
-        field,
-        display: viewField?.display ?? getDefaultViewFieldDisplay(view.layout),
-        index: viewField?.index ?? field.index,
-        width: viewField?.width ?? getDefaultFieldWidth(field.type),
-      };
-    })
-    .filter((field) => field.display)
-    .sort((a, b) => compareString(a.index, b.index));
-
-  const [isSearchBarOpened, setIsSearchBarOpened] = useState(false);
-  const [isSortsOpened, setIsSortsOpened] = useState(false);
-  const [openedFieldFilters, setOpenedFieldFilters] = useState<string[]>([]);
+  const contextValue = useDatabaseViewValue(view);
 
   return (
-    <DatabaseViewContext.Provider
-      value={{
-        id: view.id,
-        name: view.name,
-        avatar: view.avatar,
-        layout: view.layout,
-        fields,
-        filters: Object.values(view.filters ?? {}),
-        sorts: Object.values(view.sorts ?? {}),
-        groupBy: view.groupBy,
-        nameWidth: view.nameWidth ?? getDefaultNameWidth(),
-        isSearchBarOpened: isSearchBarOpened || openedFieldFilters.length > 0,
-        isSortsOpened,
-        isFieldFilterOpened: (fieldId: string) =>
-          openedFieldFilters.includes(fieldId),
-        initFieldFilter: (fieldId: string) => {
-          workspace.collections.nodes.update(view.id, (draft) => {
-            if (draft.type !== 'database_view') return;
-
-            const existingFilter = draft.filters?.[fieldId];
-            if (existingFilter) {
-              setOpenedFieldFilters((prev) =>
-                prev.filter((id) => id !== fieldId)
-              );
-              return;
-            }
-
-            if (fieldId !== SpecialId.Name) {
-              const field = database.fields.find((f) => f.id === fieldId);
-              if (!field) {
-                return;
-              }
-            }
-
-            const filter: DatabaseViewFilterAttributes = {
-              id: fieldId,
-              fieldId,
-              type: 'field',
-              operator: 'equals',
-              value: '',
-            };
-
-            draft.filters = {
-              ...draft.filters,
-              [fieldId]: filter,
-            };
-
-            setOpenedFieldFilters((prev) => [...prev, fieldId]);
-          });
-        },
-        initFieldSort: async (fieldId: string, direction: SortDirection) => {
-          if (!database.canEdit || database.isLocked) {
-            return;
-          }
-
-          const existingSort = view.sorts?.[fieldId];
-          if (existingSort && existingSort.direction === direction) {
-            return;
-          }
-
-          workspace.collections.nodes.update(view.id, (draft) => {
-            if (draft.type !== 'database_view') return;
-
-            const existingSort = draft.sorts?.[fieldId];
-            if (existingSort && existingSort.direction === direction) {
-              return;
-            }
-
-            if (fieldId !== SpecialId.Name) {
-              const field = database.fields.find((f) => f.id === fieldId);
-              if (!field) {
-                return;
-              }
-            }
-
-            const sort: DatabaseViewSortAttributes = {
-              id: fieldId,
-              fieldId,
-              direction,
-            };
-
-            draft.sorts = {
-              ...draft.sorts,
-              [fieldId]: sort,
-            };
-          });
-        },
-        openSearchBar: () => {
-          setIsSearchBarOpened(true);
-        },
-        closeSearchBar: () => {
-          setIsSearchBarOpened(false);
-        },
-        openSorts: () => {
-          setIsSortsOpened(true);
-        },
-        closeSorts: () => {
-          setIsSortsOpened(false);
-        },
-        openFieldFilter: (fieldId: string) => {
-          setOpenedFieldFilters((prev) => [...prev, fieldId]);
-        },
-        closeFieldFilter: (fieldId: string) => {
-          setOpenedFieldFilters((prev) => prev.filter((id) => id !== fieldId));
-        },
-        createRecord: async (filters?: DatabaseViewFilterAttributes[]) => {
-          const viewFilters = Object.values(view.filters ?? {}) ?? [];
-          const extraFilters = filters ?? [];
-
-          const allFilters = [...viewFilters, ...extraFilters];
-          const fields = generateFieldValuesFromFilters(
-            database.fields,
-            allFilters,
-            workspace.userId
-          );
-
-          const recordId = generateId(IdType.Record);
-          const record: LocalRecordNode = {
-            id: recordId,
-            type: 'record',
-            parentId: database.id,
-            rootId: database.rootId,
-            databaseId: database.id,
-            name: '',
-            fields,
-            createdAt: new Date().toISOString(),
-            createdBy: workspace.userId,
-            updatedAt: null,
-            updatedBy: null,
-            localRevision: '0',
-            serverRevision: '0',
-          };
-
-          const nodes = workspace.collections.nodes;
-          nodes.insert(record);
-
-          navigate({
-            from: '/workspace/$userId/$nodeId',
-            to: 'modal/$modalNodeId',
-            params: { modalNodeId: record.id },
-          });
-        },
-      }}
-    >
+    <DatabaseViewContext.Provider value={contextValue}>
       <div className="w-full h-full group/database">
         {match(view.layout)
           .with('table', () => <TableView />)

--- a/packages/ui/src/components/nodes/node-container.tsx
+++ b/packages/ui/src/components/nodes/node-container.tsx
@@ -1,4 +1,5 @@
-import { Outlet } from '@tanstack/react-router';
+import { Outlet, useNavigate } from '@tanstack/react-router';
+import { useCallback } from 'react';
 
 import { ChannelContainer } from '@colanode/ui/components/channels/channel-container';
 import { ChatContainer } from '@colanode/ui/components/chats/chat-container';
@@ -14,6 +15,7 @@ import { PageContainer } from '@colanode/ui/components/pages/page-container';
 import { RecordContainer } from '@colanode/ui/components/records/record-container';
 import { SpaceContainer } from '@colanode/ui/components/spaces/space-container';
 import { ContainerType } from '@colanode/ui/contexts/container';
+import { NavigationContext } from '@colanode/ui/contexts/navigation';
 import { useNode } from '@colanode/ui/contexts/node';
 import { useNodeRadar } from '@colanode/ui/hooks/use-node-radar';
 
@@ -72,11 +74,34 @@ export const NodeContainer = ({
   nodeId,
   onFullscreen,
 }: NodeContainerProps) => {
+  const navigate = useNavigate();
+
+  const openNode = useCallback(
+    (targetNodeId: string, nodeType: string) => {
+      if (nodeType === 'record') {
+        navigate({
+          from: '/workspace/$userId/$nodeId',
+          to: 'modal/$modalNodeId',
+          params: { modalNodeId: targetNodeId },
+        });
+      } else {
+        navigate({
+          from: '/workspace/$userId',
+          to: '$nodeId',
+          params: { nodeId: targetNodeId },
+        });
+      }
+    },
+    [navigate]
+  );
+
   return (
     <>
-      <NodeProvider nodeId={nodeId}>
-        <NodeContent type={type} onFullscreen={onFullscreen} />
-      </NodeProvider>
+      <NavigationContext.Provider value={{ openNode }}>
+        <NodeProvider nodeId={nodeId}>
+          <NodeContent type={type} onFullscreen={onFullscreen} />
+        </NodeProvider>
+      </NavigationContext.Provider>
       <Outlet />
     </>
   );

--- a/packages/ui/src/contexts/navigation.ts
+++ b/packages/ui/src/contexts/navigation.ts
@@ -1,0 +1,11 @@
+import { createContext, useContext } from 'react';
+
+interface NavigationContext {
+  openNode: (nodeId: string, nodeType: string) => void;
+}
+
+export const NavigationContext = createContext<NavigationContext>(
+  {} as NavigationContext
+);
+
+export const useNavigation = () => useContext(NavigationContext);

--- a/packages/ui/src/hooks/use-database-view-value.ts
+++ b/packages/ui/src/hooks/use-database-view-value.ts
@@ -1,0 +1,176 @@
+import { useState } from 'react';
+
+import {
+  LocalDatabaseViewNode,
+  LocalRecordNode,
+  ViewField,
+} from '@colanode/client/types';
+import {
+  compareString,
+  DatabaseViewFilterAttributes,
+  DatabaseViewSortAttributes,
+  IdType,
+  SortDirection,
+  SpecialId,
+  generateId,
+} from '@colanode/core';
+import { useDatabase } from '@colanode/ui/contexts/database';
+import { useNavigation } from '@colanode/ui/contexts/navigation';
+import { useWorkspace } from '@colanode/ui/contexts/workspace';
+import {
+  generateFieldValuesFromFilters,
+  getDefaultFieldWidth,
+  getDefaultNameWidth,
+  getDefaultViewFieldDisplay,
+} from '@colanode/ui/lib/databases';
+
+export const useDatabaseViewValue = (view: LocalDatabaseViewNode) => {
+  const workspace = useWorkspace();
+  const database = useDatabase();
+  const navigation = useNavigation();
+
+  const fields: ViewField[] = database.fields
+    .map((field) => {
+      const viewField = view.fields?.[field.id];
+
+      return {
+        field,
+        display: viewField?.display ?? getDefaultViewFieldDisplay(view.layout),
+        index: viewField?.index ?? field.index,
+        width: viewField?.width ?? getDefaultFieldWidth(field.type),
+      };
+    })
+    .filter((field) => field.display)
+    .sort((a, b) => compareString(a.index, b.index));
+
+  const [isSearchBarOpened, setIsSearchBarOpened] = useState(false);
+  const [isSortsOpened, setIsSortsOpened] = useState(false);
+  const [openedFieldFilters, setOpenedFieldFilters] = useState<string[]>([]);
+
+  return {
+    id: view.id,
+    name: view.name,
+    avatar: view.avatar,
+    layout: view.layout,
+    fields,
+    filters: Object.values(view.filters ?? {}),
+    sorts: Object.values(view.sorts ?? {}),
+    groupBy: view.groupBy,
+    nameWidth: view.nameWidth ?? getDefaultNameWidth(),
+    isSearchBarOpened: isSearchBarOpened || openedFieldFilters.length > 0,
+    isSortsOpened,
+    isFieldFilterOpened: (fieldId: string) =>
+      openedFieldFilters.includes(fieldId),
+    initFieldFilter: (fieldId: string) => {
+      workspace.collections.nodes.update(view.id, (draft) => {
+        if (draft.type !== 'database_view') return;
+
+        const existingFilter = draft.filters?.[fieldId];
+        if (existingFilter) {
+          setOpenedFieldFilters((prev) =>
+            prev.filter((id) => id !== fieldId)
+          );
+          return;
+        }
+
+        if (fieldId !== SpecialId.Name) {
+          const field = database.fields.find((f) => f.id === fieldId);
+          if (!field) {
+            return;
+          }
+        }
+
+        const filter: DatabaseViewFilterAttributes = {
+          id: fieldId,
+          fieldId,
+          type: 'field',
+          operator: 'equals',
+          value: '',
+        };
+
+        draft.filters = {
+          ...draft.filters,
+          [fieldId]: filter,
+        };
+
+        setOpenedFieldFilters((prev) => [...prev, fieldId]);
+      });
+    },
+    initFieldSort: (fieldId: string, direction: SortDirection) => {
+      if (!database.canEdit || database.isLocked) {
+        return;
+      }
+
+      workspace.collections.nodes.update(view.id, (draft) => {
+        if (draft.type !== 'database_view') return;
+
+        const existingSort = draft.sorts?.[fieldId];
+        if (existingSort && existingSort.direction === direction) {
+          return;
+        }
+
+        if (fieldId !== SpecialId.Name) {
+          const field = database.fields.find((f) => f.id === fieldId);
+          if (!field) {
+            return;
+          }
+        }
+
+        const sort: DatabaseViewSortAttributes = {
+          id: fieldId,
+          fieldId,
+          direction,
+        };
+
+        draft.sorts = {
+          ...draft.sorts,
+          [fieldId]: sort,
+        };
+      });
+    },
+    openSearchBar: () => setIsSearchBarOpened(true),
+    closeSearchBar: () => setIsSearchBarOpened(false),
+    openSorts: () => setIsSortsOpened(true),
+    closeSorts: () => setIsSortsOpened(false),
+    openFieldFilter: (fieldId: string) => {
+      setOpenedFieldFilters((prev) => [...prev, fieldId]);
+    },
+    closeFieldFilter: (fieldId: string) => {
+      setOpenedFieldFilters((prev) => prev.filter((id) => id !== fieldId));
+    },
+    createRecord: (filters?: DatabaseViewFilterAttributes[]) => {
+      if (!database.canCreateRecord || database.isLocked) {
+        return;
+      }
+
+      const allFilters = [
+        ...(Object.values(view.filters ?? {}) ?? []),
+        ...(filters ?? []),
+      ];
+
+      const recordId = generateId(IdType.Record);
+      const record: LocalRecordNode = {
+        id: recordId,
+        type: 'record',
+        parentId: database.id,
+        rootId: database.rootId,
+        databaseId: database.id,
+        name: '',
+        fields: generateFieldValuesFromFilters(
+          database.fields,
+          allFilters,
+          workspace.userId
+        ),
+        createdAt: new Date().toISOString(),
+        createdBy: workspace.userId,
+        updatedAt: null,
+        updatedBy: null,
+        localRevision: '0',
+        serverRevision: '0',
+      };
+
+      workspace.collections.nodes.insert(record);
+      navigation.openNode(record.id, 'record');
+    },
+  };
+};


### PR DESCRIPTION
## Summary

- Extract duplicated database view business logic from mobile's `database-runtime.tsx` (734→188 lines, 74% reduction) into shared `packages/ui` hooks and components
- Add `NavigationContext` abstraction so shared components work on both desktop (TanStack Router) and mobile (WebView bridge) without platform-specific imports
- Extract `useDatabaseViewValue` hook containing all `DatabaseViewContext` computation (fields, filters, sorts, record creation) previously copy-pasted between `view.tsx` and `database-runtime.tsx`
- Fix desktop `TableViewNameCell` permission bug (was hardcoded `canEdit = true`, now uses `useRecord().canEdit`), merge mobile's view-delete safeguards into shared `TableViewSettings`, and keep open-record button visible on mobile touch
- Add `database` node type support to mobile rename-node-sheet

## Test plan

- [ ] Desktop/web: open database, verify table view renders, filters/sorts work, record creation opens modal, fullscreen button works for inline databases, view settings (rename, lock, delete) work
- [ ] Mobile: open database in WebView, verify table view renders, record open button is visible, record creation navigates correctly, unsupported view fallback shows for board/calendar
- [ ] Mobile: long-press a database node, verify rename works without crash
- [ ] Run `cd apps/web && npm run test` — all tests pass
- [ ] Run `cd apps/mobile/webviews/editor && npm run build` — builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)