### PR TITLE
Fix WebView error reporter to show message instead of stack

### DIFF
--- a/apps/mobile/src/components/pages/page-webview.tsx
+++ b/apps/mobile/src/components/pages/page-webview.tsx
@@ -537,9 +537,7 @@ export const PageWebView = forwardRef<PageWebViewHandle, PageWebViewProps>(
           window.__colanodeBridgeReportError = function(prefix, value) {
             var message = prefix;
             if (value) {
-              if (value.stack) {
-                message += ': ' + value.stack;
-              } else if (value.message) {
+              if (value.message) {
                 message += ': ' + value.message;
               } else {
                 message += ': ' + String(value);


### PR DESCRIPTION
## Summary
- Fix the injected WebView error reporter to prefer `.message` over `.stack` when logging errors
- Previously, minified WebKit stack traces were shown first, hiding the actual error message which made debugging difficult

## Test plan
- [ ] Trigger a WebView error (e.g. database filter crash) and verify the console error shows a readable message

🤖 Generated with [Claude Code](https://claude.com/claude-code)