### PR TITLE
Fix user role update workspace

### DIFF
--- a/packages/client/src/handlers/mutations/users/user-role-update.ts
+++ b/packages/client/src/handlers/mutations/users/user-role-update.ts
@@ -24,7 +24,7 @@ export class UserRoleUpdateMutationHandler
 
       const output = await workspace.account.client
         .patch(
-          `v1/workspaces/${workspace.workspaceId}/users/${input.userId}/role`,
+          `v1/workspaces/${workspace.workspaceId}/users/${input.targetUserId}/role`,
           {
             json: body,
           }

--- a/packages/client/src/mutations/users/user-role-update.ts
+++ b/packages/client/src/mutations/users/user-role-update.ts
@@ -3,6 +3,7 @@ import { WorkspaceRole } from '@colanode/core';
 export type UserRoleUpdateMutationInput = {
   type: 'user.role.update';
   userId: string;
+  targetUserId: string;
   role: WorkspaceRole;
 };
 

--- a/packages/client/src/services/workspaces/user-service.ts
+++ b/packages/client/src/services/workspaces/user-service.ts
@@ -17,7 +17,13 @@ export class UserService {
       `Upserting user ${user.id} in workspace ${this.workspace.workspaceId}`
     );
 
-    const createdUser = await this.workspace.database
+    const existingUser = await this.workspace.database
+      .selectFrom('users')
+      .selectAll()
+      .where('id', '=', user.id)
+      .executeTakeFirst();
+
+    const upsertedUser = await this.workspace.database
       .insertInto('users')
       .returningAll()
       .values({
@@ -50,15 +56,16 @@ export class UserService {
       )
       .executeTakeFirst();
 
-    if (createdUser) {
+    if (upsertedUser) {
+      const eventType = existingUser ? 'user.updated' : 'user.created';
       eventBus.publish({
-        type: 'user.created',
+        type: eventType,
         workspace: {
           workspaceId: this.workspace.workspaceId,
           userId: this.workspace.userId,
           accountId: this.workspace.accountId,
         },
-        user: mapUser(createdUser),
+        user: mapUser(upsertedUser),
       });
     }
   }
@@ -68,7 +75,13 @@ export class UserService {
       `Syncing server user ${user.id} in workspace ${this.workspace.workspaceId}`
     );
 
-    const createdUser = await this.workspace.database
+    const existingUser = await this.workspace.database
+      .selectFrom('users')
+      .selectAll()
+      .where('id', '=', user.id)
+      .executeTakeFirst();
+
+    const syncedUser = await this.workspace.database
       .insertInto('users')
       .returningAll()
       .values({
@@ -101,15 +114,16 @@ export class UserService {
       )
       .executeTakeFirst();
 
-    if (createdUser) {
+    if (syncedUser) {
+      const eventType = existingUser ? 'user.updated' : 'user.created';
       eventBus.publish({
-        type: 'user.created',
+        type: eventType,
         workspace: {
           workspaceId: this.workspace.workspaceId,
           userId: this.workspace.userId,
           accountId: this.workspace.accountId,
         },
-        user: mapUser(createdUser),
+        user: mapUser(syncedUser),
       });
     }
   }

--- a/packages/ui/src/components/workspaces/workspace-user-role-dropdown.tsx
+++ b/packages/ui/src/components/workspaces/workspace-user-role-dropdown.tsx
@@ -53,13 +53,13 @@ const roles: WorkspaceRoleItem[] = [
 ];
 
 interface WorkspaceUserRoleDropdownProps {
-  userId: string;
+  targetUserId: string;
   value: WorkspaceRole;
   canEdit: boolean;
 }
 
 export const WorkspaceUserRoleDropdown = ({
-  userId,
+  targetUserId,
   value,
   canEdit,
 }: WorkspaceUserRoleDropdownProps) => {
@@ -103,9 +103,8 @@ export const WorkspaceUserRoleDropdown = ({
                 mutate({
                   input: {
                     type: 'user.role.update',
-                    accountId: workspace.accountId,
-                    workspaceId: workspace.workspaceId,
-                    userId: userId,
+                    userId: workspace.userId,
+                    targetUserId: targetUserId,
                     role: role.value,
                   },
                   onError(error) {

--- a/packages/ui/src/components/workspaces/workspace-users-container.tsx
+++ b/packages/ui/src/components/workspaces/workspace-users-container.tsx
@@ -71,7 +71,7 @@ export const WorkspaceUsersContainer = () => {
                     <p className="text-sm text-muted-foreground">{email}</p>
                   </div>
                   <WorkspaceUserRoleDropdown
-                    userId={user.id}
+                    targetUserId={user.id}
                     value={role}
                     canEdit={canEditUsers}
                   />


### PR DESCRIPTION
## Fix: User Role Update in Workspace

### Problems

Two bugs were found in the workspace user role management flow:

**1. Wrong user ID sent in role update API call**

`UserRoleUpdateMutationHandler` was using `input.userId` (the current logged-in user) as the target in the API URL instead of `input.targetUserId` (the user whose role is being changed). This caused the role update request to target the wrong user.

Additionally, `WorkspaceUserRoleDropdown` was passing `accountId` and `workspaceId` directly from the component into the mutation input, while the handler already resolves these from workspace context — leading to confusion between the acting user and the target user.

**2. UI not reflecting role changes after update**

`UserService.upsertUser()` and `UserService.syncServerUser()` always emitted a `user.created` event even when the user record already existed (i.e., an upsert/update scenario). Components listening for `user.updated` events never received the signal, so the UI did not re-render after a role change.

---

### Changes

**`packages/client/src/mutations/users/user-role-update.ts`**
- Added `targetUserId` field to `UserRoleUpdateMutationInput` to explicitly distinguish the target user from the acting user (`userId`).

**`packages/client/src/handlers/mutations/users/user-role-update.ts`**
- Fixed API URL to use `input.targetUserId` instead of `input.userId`.

**`packages/ui/src/components/workspaces/workspace-user-role-dropdown.tsx`**
- Renamed prop `userId` → `targetUserId` for clarity.
- Fixed mutation input: pass `userId: workspace.userId` (acting user) and `targetUserId` (target user) instead of incorrectly passing `accountId`/`workspaceId`.

**`packages/ui/src/components/workspaces/workspace-users-container.tsx`**
- Updated prop name to `targetUserId` to match the dropdown component change.

**`packages/client/src/services/workspaces/user-service.ts`**
- Before upserting, check whether the user already exists in the local SQLite database.
- Emit `user.updated` event if the record existed, or `user.created` if it is new.
- Applied to both `upsertUser()` and `syncServerUser()`.

---

### Testing

1. Open workspace settings → Members.
2. Change the role of any member.
3. Verify the dropdown immediately reflects the new role without a page refresh.
4. Verify the correct user's role is updated (not the acting admin's).
